### PR TITLE
Test case location

### DIFF
--- a/examples/jest.config.js
+++ b/examples/jest.config.js
@@ -1,6 +1,5 @@
 /** @type {import('jest').Config} */
 const config = {
-  testTimeout: 10000,
   reporters: [
     // "default",
     ["@currents/jest", {}],
@@ -8,10 +7,12 @@ const config = {
   projects: [
     {
       displayName: "spec",
+      testLocationInResults: true,
       testMatch: ["<rootDir>/**/*.spec.ts"],
     },
     {
       displayName: "test",
+      testLocationInResults: true,
       testMatch: ["<rootDir>/**/*.test.ts"],
     },
   ],

--- a/examples/src/same-title.test.ts
+++ b/examples/src/same-title.test.ts
@@ -1,0 +1,17 @@
+jest.retryTimes(2);
+
+describe("Test cases with same title", () => {
+  let j = 0;
+
+  test("Test case example", () => {
+    expect(j++).toBe(2);
+  });
+
+  test.skip("Test case example", () => {
+    expect(1).toBe(1);
+  });
+
+  test("Test case example", () => {
+    expect(1).toBe(1);
+  });
+});


### PR DESCRIPTION
Changes:
- update `examples`: add a spec with test cases with the same title; added `testLocationInResults: true` in `jest.config.js` to have test location; removed useless `testTimeout`
- add test location to the report, when available
- fix a logic error, that was triggered when the suite had only one spec with one skipped describe block. The error: only the `onTestFileResult` hook was called and `this.resultsDeferred[testCaseKey]` was `undefined`.