### PR TITLE
[CSR-1382] fix: filter irrelevant options from jest configuration

### DIFF
--- a/packages/cmd/src/discovery/jest/args/args.ts
+++ b/packages/cmd/src/discovery/jest/args/args.ts
@@ -3,7 +3,6 @@ import { omit } from "lodash";
 const ignoredOptions = [
   "bail", // causes unexpected behaviour
   "clearCache",
-  "clearMocks",
   "collectCoverage",
   "collectCoverageFrom",
   "color",
@@ -29,7 +28,6 @@ const ignoredOptions = [
   "notifyMode",
   "openHandlesTimeout",
   "outputFile",
-  "prettierPath",
   "reporters",
   "runner",
   "shard",

--- a/packages/cmd/src/discovery/jest/args/config.ts
+++ b/packages/cmd/src/discovery/jest/args/config.ts
@@ -17,7 +17,8 @@ export async function getConfigFilePath(
       explicitConfigFilePath
     );
 
-    const parsedConfigObject = omit(initialConfig, [
+    const configOptionsToAvoid = [
+      // from docs: https://jestjs.io/docs/configuration
       "collectCoverage",
       "collectCoverageFrom",
       "coverageDirectory",
@@ -25,21 +26,68 @@ export async function getConfigFilePath(
       "coverageProvider",
       "coverageReporters",
       "coverageThreshold",
-      "detectLeaks",
-      "detectOpenHandles",
-      "reporters",
-      "logHeapUsage",
-      "listTests",
+      "errorOnDeprecated",
+      "forceCoverageMatch",
       "notify",
       "notifyMode",
-      "silent",
+      "openHandlesTimeout",
+      "reporters",
+      "runner",
+      "showSeed",
+      "testFailureExitCode",
       "verbose",
+      "watchPathIgnorePatterns",
+      "watchPlugins",
+      "watchman",
+
+      // from Config type
+      "bail", // causes unexpected behaviour
+      "clearCache",
+      "color",
+      "colors",
+      "debug",
+      "detectLeaks",
+      "detectOpenHandles",
+      "expand",
+      "forceExit",
+      "json",
+      "listTests",
+      "logHeapUsage",
+      "noStackTrace",
+      "outputFile",
+      "shard",
+      "showConfig",
+      "silent",
+      "testNamePattern",
+      "waitNextEventLoopTurnForUnhandledRejectionEvents",
       "watch",
       "watchAll",
-      "watchman",
-      "watchPlugins",
-      "shard",
-    ]);
+    ];
+
+    // from InitialProjectOptions type
+    const projectConfigOptionsToAvoid = [
+      "collectCoverageFrom",
+      "coverageDirectory",
+      "coveragePathIgnorePatterns",
+      "detectLeaks",
+      "detectOpenHandles",
+      "errorOnDeprecated",
+      "forceCoverageMatch",
+      "openHandlesTimeout",
+      "runner",
+      "watchPathIgnorePatterns",
+    ];
+
+    const parsedConfigObject = omit(initialConfig, configOptionsToAvoid);
+
+    if (parsedConfigObject.projects) {
+      parsedConfigObject.projects = parsedConfigObject.projects.map(
+        (project) =>
+          typeof project !== "string"
+            ? omit(project, projectConfigOptionsToAvoid)
+            : project
+      );
+    }
 
     if (
       parsedConfigObject.rootDir &&


### PR DESCRIPTION
Some options provided via `jest.config` file can stop the `currents upload` script from reporting the results. I filtered the options that can cause problems for main and project level configuration.

[Screencast from 07-24-2024 06:05:35 PM.webm](https://github.com/user-attachments/assets/04830d99-f612-4966-a789-05383ed22de4)
