### PR TITLE
[CSR-1510] fix: make missing config variables user-friendly

### DIFF
--- a/packages/cmd/src/bin/index.ts
+++ b/packages/cmd/src/bin/index.ts
@@ -7,10 +7,11 @@ import("dotenv/config");
 import { CommanderError } from "commander";
 import { getCurrentsConfig, setCurrentsConfig } from "../config";
 import { currentsReporter } from "../index";
+import { ValidationError } from "../lib";
 import { error, info, success } from "../logger";
 import { CLIManager } from "./cli-config";
 
-function runScript() {
+async function runScript() {
   const cliManager = new CLIManager();
   setCurrentsConfig(cliManager.parsedConfig);
   const config = getCurrentsConfig();
@@ -32,6 +33,12 @@ runScript()
       error(e.message);
       process.exit(e.exitCode);
     }
+
+    if (e instanceof ValidationError) {
+      error(e.message);
+      process.exit(1);
+    }
+
     error("Script execution failed:", e);
     process.exit(1);
   });


### PR DESCRIPTION
Tested by publishing `@currents/cmd` to a local registry using [verdaccio](https://www.npmjs.com/package/verdaccio)

![image](https://github.com/user-attachments/assets/2692e7db-e038-4714-b085-438bf3458f73)
