### PR TITLE
[CSR-1645] fix: Rename from --paths to --path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ To explore additional examples and filtering options for receiving runs, you can
 
 ### Caching artifacts
 
-The `currents cache` command allows you to archive files from specified locations and save them under an ID in Currents storage. It also stores a meta file with configuration data. You can provide the ID manually or it can be generated based on CI environment variables (only GitHub and GitLab are supported). The files to archive can be defined using the `paths <path-1,path2,...,path-n>` CLI option or predefined using a `preset`.
+The `currents cache` command allows you to archive files from specified locations and save them under an ID in Currents storage. It also stores a meta file with configuration data. You can provide the ID manually or it can be generated based on CI environment variables (only GitHub and GitLab are supported). The files to archive can be defined using the `path <path-1,path2,...,path-n>` CLI option or predefined using a `preset`.
 
-To cache files, run `npx currents cache set --key <record-key> --id <id> --paths <path-1,path-2,...path-n>`.
+To cache files, run `npx currents cache set --key <record-key> --id <id> --path <path-1,path-2,...path-n>`.
 
 To download files, run `npx currents cache set --key <record-key> --preset last-run`.
 

--- a/packages/cmd/README.md
+++ b/packages/cmd/README.md
@@ -76,7 +76,7 @@ The `currents cache` command allows you to archive files from specified location
 To cache files, use the following command:
 
 ```sh
-npx currents cache set --key <record-key> --id <id> --paths <path-1,path-2,...path-n>
+npx currents cache set --key <record-key> --id <id> --path <path-1,path-2,...path-n>
 ```
 
 To download files, use the following command:

--- a/packages/cmd/src/commands/cache/index.ts
+++ b/packages/cmd/src/commands/cache/index.ts
@@ -8,7 +8,7 @@ import {
   matrixIndexOption,
   matrixTotalOption,
   outputDirOption,
-  pathsOption,
+  pathOption,
   presetOption,
   presetOutputOption,
   pwOutputDirOption,
@@ -22,7 +22,7 @@ const getExample = (name: string) => `
 ${chalk.bold('Examples')}
 
 Save files to the cache under a specific ID:
-${dim(`${name} ${COMMAND_NAME} set --key <record-key> --id <id> --paths <path-1,path-2,...path-n>`)}
+${dim(`${name} ${COMMAND_NAME} set --key <record-key> --id <id> --path <path-1,path-2,...path-n>`)}
 
 Retrieve files from the cache saved under a specific ID:
 ${dim(`${name} ${COMMAND_NAME} get --key <record-key> --id <id>`)}
@@ -57,7 +57,7 @@ export const getCacheSetCommand = () => {
     .addOption(recordKeyOption)
     .addOption(idOption)
     .addOption(presetOption)
-    .addOption(pathsOption)
+    .addOption(pathOption)
     .addOption(debugOption)
     .addOption(pwOutputDirOption)
     .addOption(matrixIndexOption)

--- a/packages/cmd/src/commands/cache/options.ts
+++ b/packages/cmd/src/commands/cache/options.ts
@@ -17,8 +17,8 @@ export const idOption = new Option(
   'The ID the data is saved under in the cache'
 );
 
-export const pathsOption = new Option(
-  '--paths <paths>',
+export const pathOption = new Option(
+  '--path <path>',
   'Comma-separated list of paths to cache'
 ).argParser(parseCommaSeparatedList);
 

--- a/packages/cmd/src/config/cache/config.ts
+++ b/packages/cmd/src/config/cache/config.ts
@@ -26,7 +26,7 @@ type CommonConfig = {
 
 export type CacheSetCommandConfig = CacheCommandConfig &
   CommonConfig & {
-    paths?: string[];
+    path?: string[];
     pwOutputDir?: string;
   };
 

--- a/packages/cmd/src/config/cache/env.ts
+++ b/packages/cmd/src/config/cache/env.ts
@@ -30,9 +30,9 @@ const cacheSetCommandConfigKeys = {
     name: 'Preset output path',
     cli: '--preset-output',
   },
-  paths: {
+  path: {
     name: 'Paths to cache',
-    cli: '--paths',
+    cli: '--path',
   },
   matrixIndex: {
     name: 'Matrix index',

--- a/packages/cmd/src/config/cache/options.ts
+++ b/packages/cmd/src/config/cache/options.ts
@@ -25,7 +25,7 @@ export function cacheSetCommandOptsToConfig(
     id: options.id,
     preset: options.preset,
     pwOutputDir: options.pwOutputDir,
-    paths: options.paths,
+    path: options.path,
     debug: options.debug,
     matrixIndex: options.matrixIndex,
     matrixTotal: options.matrixTotal,

--- a/packages/cmd/src/services/cache/lib.ts
+++ b/packages/cmd/src/services/cache/lib.ts
@@ -7,7 +7,7 @@ export type MetaFile = {
   id: string;
   orgId: string;
   config: CacheSetCommandConfig;
-  paths: string[];
+  path: string[];
   ci: Record<string, unknown>;
   createdAt: string;
 };
@@ -16,20 +16,20 @@ export function createMeta({
   config,
   cacheId,
   orgId,
-  paths,
+  path,
   ci,
 }: {
   config: CacheSetCommandConfig;
   cacheId: string;
   orgId: string;
-  paths: string[];
+  path: string[];
   ci: Record<string, unknown>;
 }) {
   const meta = {
     id: cacheId,
     orgId,
     config: omit(config, 'recordKey'),
-    paths,
+    path,
     ci,
     createdAt: new Date().toISOString(),
   };

--- a/packages/cmd/src/services/cache/set.ts
+++ b/packages/cmd/src/services/cache/set.ts
@@ -21,7 +21,7 @@ export async function handleSetCache() {
     const { recordKey, id, preset, pwOutputDir, matrixIndex, matrixTotal } =
       config.values;
 
-    const paths = config.values.paths ? filterPaths(config.values.paths) : [];
+    const paths = config.values.path ? filterPaths(config.values.path) : [];
 
     const uploadPaths: string[] = [];
 
@@ -62,7 +62,7 @@ export async function handleSetCache() {
         config: config.values,
         ci,
         orgId: result.orgId,
-        paths: uploadPaths,
+        path: uploadPaths,
       }),
       cacheId: result.cacheId,
       uploadUrl: result.metaUploadUrl,


### PR DESCRIPTION
- [x] verify workflow examples
  - GHA workflows does not use `--path`
  - GitLab pipelines does not use `--path`
- [x] update GHA template
  - renamed template option from `paths` to `path`, v1.0.7
- [x] test the action template after update