### PR TITLE
[CSR-1646] fix: Set exit code 1 on error

### DIFF
--- a/packages/cmd/src/commands/cache/get.ts
+++ b/packages/cmd/src/commands/cache/get.ts
@@ -15,21 +15,15 @@ export type CacheGetCommandOpts = ReturnType<
 >;
 
 export async function getCacheGetHandler(options: CacheGetCommandOpts) {
-  await commandHandler(
-    async (opts) => {
-      setCacheGetCommandConfig(cacheGetCommandOptsToConfig(opts));
-      const config = getCacheCommandConfig();
+  await commandHandler(async (opts) => {
+    setCacheGetCommandConfig(cacheGetCommandOptsToConfig(opts));
+    const config = getCacheCommandConfig();
 
-      debug('Config: %o', {
-        ...config.values,
-        recordKey: config.values?.recordKey ? '*****' : undefined,
-      });
+    debug('Config: %o', {
+      ...config.values,
+      recordKey: config.values?.recordKey ? '*****' : undefined,
+    });
 
-      await handleGetCache();
-    },
-    options,
-    {
-      failOnError: options.fail,
-    }
-  );
+    await handleGetCache();
+  }, options);
 }

--- a/packages/cmd/src/commands/cache/index.ts
+++ b/packages/cmd/src/commands/cache/index.ts
@@ -3,11 +3,11 @@ import { dim } from '@logger';
 import chalk from 'chalk';
 import { getCacheGetHandler } from './get';
 import {
+  continueOption,
   debugOption,
   idOption,
   matrixIndexOption,
   matrixTotalOption,
-  noFailOption,
   outputDirOption,
   pathOption,
   presetOption,
@@ -63,7 +63,6 @@ export const getCacheSetCommand = () => {
     .addOption(pwOutputDirOption)
     .addOption(matrixIndexOption)
     .addOption(matrixTotalOption)
-    .addOption(noFailOption)
     .action(getCacheSetHandler);
 
   return command;
@@ -81,7 +80,7 @@ export const getCacheGetCommand = () => {
     .addOption(debugOption)
     .addOption(matrixIndexOption)
     .addOption(matrixTotalOption)
-    .addOption(noFailOption)
+    .addOption(continueOption)
     .action(getCacheGetHandler);
 
   return command;

--- a/packages/cmd/src/commands/cache/options.ts
+++ b/packages/cmd/src/commands/cache/options.ts
@@ -73,7 +73,7 @@ function validatePositiveInteger(value: string) {
   return parsedValue;
 }
 
-export const noFailOption = new Option(
-  '--no-fail',
-  'Do not fail the process if the command fails'
-);
+export const continueOption = new Option(
+  '--continue',
+  'Continue the script execution if the cache is not found'
+).default(false);

--- a/packages/cmd/src/commands/cache/set.ts
+++ b/packages/cmd/src/commands/cache/set.ts
@@ -15,21 +15,15 @@ export type CacheSetCommandOpts = ReturnType<
 >;
 
 export async function getCacheSetHandler(options: CacheSetCommandOpts) {
-  await commandHandler(
-    async (opts) => {
-      setCacheSetCommandConfig(cacheSetCommandOptsToConfig(opts));
-      const config = getCacheCommandConfig();
+  await commandHandler(async (opts) => {
+    setCacheSetCommandConfig(cacheSetCommandOptsToConfig(opts));
+    const config = getCacheCommandConfig();
 
-      debug('Config: %o', {
-        ...config.values,
-        recordKey: config.values?.recordKey ? '*****' : undefined,
-      });
+    debug('Config: %o', {
+      ...config.values,
+      recordKey: config.values?.recordKey ? '*****' : undefined,
+    });
 
-      await handleSetCache();
-    },
-    options,
-    {
-      failOnError: options.fail,
-    }
-  );
+    await handleSetCache();
+  }, options);
 }

--- a/packages/cmd/src/commands/utils.ts
+++ b/packages/cmd/src/commands/utils.ts
@@ -1,5 +1,5 @@
 import { CommanderError } from '@commander-js/extra-typings';
-import { error, warnWithNoTrace } from '@logger';
+import { error } from '@logger';
 import { enableDebug } from '../debug';
 
 export function parseCommaSeparatedList(
@@ -14,10 +14,7 @@ export function parseCommaSeparatedList(
 
 export async function commandHandler<T extends Record<string, unknown>>(
   action: (options: T) => Promise<void>,
-  commandOptions: T,
-  options?: {
-    failOnError?: boolean;
-  }
+  commandOptions: T
 ) {
   try {
     if (commandOptions.debug) {
@@ -25,16 +22,9 @@ export async function commandHandler<T extends Record<string, unknown>>(
     }
     await action(commandOptions);
     process.exit(0);
-  } catch (_e) {
-    const e = _e as Error;
-    const failOnError = options?.failOnError ?? true;
-    if (failOnError) {
-      error(e.message);
-    } else {
-      warnWithNoTrace(e.message);
-    }
-
+  } catch (e) {
+    error((e as Error).message);
     const exitCode = e instanceof CommanderError ? e.exitCode : 1;
-    process.exit(failOnError ? exitCode : 0);
+    process.exit(exitCode);
   }
 }

--- a/packages/cmd/src/config/cache/config.ts
+++ b/packages/cmd/src/config/cache/config.ts
@@ -32,6 +32,7 @@ export type CacheSetCommandConfig = CacheCommandConfig &
 
 export type CacheGetCommandConfig = CacheCommandConfig &
   CommonConfig & {
+    continue?: boolean;
     outputDir?: string;
     presetOutput?: string;
   };

--- a/packages/cmd/src/config/cache/env.ts
+++ b/packages/cmd/src/config/cache/env.ts
@@ -65,6 +65,10 @@ const cacheGetCommandConfigKeys = {
     name: 'Matrix total',
     cli: '--matrix-total',
   },
+  continue: {
+    name: 'Continue on cache miss',
+    cli: '--continue',
+  },
 } as const;
 
 export const configKeys = {

--- a/packages/cmd/src/config/cache/options.ts
+++ b/packages/cmd/src/config/cache/options.ts
@@ -14,6 +14,7 @@ export function cacheGetCommandOptsToConfig(
     debug: options.debug,
     matrixIndex: options.matrixIndex,
     matrixTotal: options.matrixTotal,
+    continue: options.continue,
   };
 }
 

--- a/packages/cmd/src/services/cache/__tests__/get.spec.ts
+++ b/packages/cmd/src/services/cache/__tests__/get.spec.ts
@@ -1,0 +1,172 @@
+import { isAxiosError } from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { retrieveCache } from '../../../api';
+import { PRESETS } from '../../../commands/cache/options';
+import {
+  CacheCommandConfig,
+  CacheGetCommandConfig,
+  getCacheCommandConfig,
+} from '../../../config/cache';
+import { getCI } from '../../../env/ciProvider';
+import { success, warnWithNoTrace } from '../../../logger';
+import { unzipBuffer } from '../fs';
+import { handleGetCache } from '../get';
+import { download } from '../network';
+import { handlePostLastRunPreset, handlePreLastRunPreset } from '../presets';
+
+const mockConfig: {
+  type: 'GET_COMMAND_CONFIG';
+  values: (CacheCommandConfig & CacheGetCommandConfig) | null;
+} = {
+  type: 'GET_COMMAND_CONFIG',
+  values: {
+    recordKey: 'testKey',
+    id: 'testId',
+    preset: PRESETS.lastRun,
+    matrixIndex: 0,
+    matrixTotal: 1,
+    outputDir: 'testOutput',
+    continue: false,
+  },
+};
+
+const mockCI: ReturnType<typeof getCI> = {
+  provider: 'testCI',
+  ciBuildId: { source: 'random', value: 'auto-ci-build-id' },
+  params: {},
+};
+
+const mockCacheResult = {
+  readUrl: 'http://cache.url',
+  metaReadUrl: 'http://meta.url',
+  cacheId: 'cacheId123',
+  orgId: 'org123',
+};
+
+const mockMetaFile = { version: '1.0' };
+
+vi.mock('../../../config/cache');
+vi.mock('../../../env/ciProvider');
+vi.mock('../../../api');
+vi.mock('../network');
+vi.mock('../fs');
+vi.mock('../presets');
+vi.mock('axios');
+vi.mock('../../../logger');
+
+describe('handleGetCache', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getCacheCommandConfig).mockReturnValue(mockConfig);
+    vi.mocked(getCI).mockReturnValue(mockCI);
+    vi.mocked(retrieveCache).mockResolvedValue(mockCacheResult);
+    vi.mocked(download).mockResolvedValue(
+      Buffer.from(JSON.stringify(mockMetaFile))
+    );
+    vi.mocked(unzipBuffer).mockResolvedValue(undefined);
+  });
+
+  const expectCacheRetrievalAndDownload = async () => {
+    await handleGetCache();
+    expect(retrieveCache).toHaveBeenCalledWith({
+      recordKey: 'testKey',
+      ci: mockCI,
+      id: 'testId',
+      config: { matrixIndex: 0, matrixTotal: 1 },
+    });
+    expect(download).toHaveBeenCalledWith('http://cache.url');
+    expect(unzipBuffer).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      mockConfig.values?.outputDir
+    );
+  };
+
+  it('should throw an error if config type is not GET_COMMAND_CONFIG', async () => {
+    vi.mocked(getCacheCommandConfig).mockReturnValue({
+      type: 'SET_COMMAND_CONFIG',
+      values: mockConfig.values,
+    });
+    await expect(handleGetCache()).rejects.toThrow('Config is missing!');
+  });
+
+  it('should throw an error if config values are not set', async () => {
+    vi.mocked(getCacheCommandConfig).mockReturnValue({
+      type: 'GET_COMMAND_CONFIG',
+      values: null,
+    });
+    await expect(handleGetCache()).rejects.toThrow('Config is missing!');
+  });
+
+  it('should call handlePreLastRunPreset if preset is lastRun', async () => {
+    await handleGetCache();
+    expect(handlePreLastRunPreset).toHaveBeenCalledWith(
+      mockConfig.values,
+      mockCI
+    );
+  });
+
+  it('should retrieve cache and download archive', async () => {
+    await expectCacheRetrievalAndDownload();
+  });
+
+  it('should download and parse meta file', async () => {
+    const jsonParseSpy = vi.spyOn(JSON, 'parse');
+    await handleGetCache();
+    expect(download).toHaveBeenCalledWith('http://meta.url');
+    expect(jsonParseSpy).toHaveBeenCalledWith(
+      Buffer.from(JSON.stringify(mockMetaFile)).toString('utf-8')
+    );
+  });
+
+  it('should call handlePostLastRunPreset if preset is lastRun', async () => {
+    await handleGetCache();
+    expect(handlePostLastRunPreset).toHaveBeenCalledWith(
+      mockConfig.values,
+      mockCI,
+      undefined
+    );
+  });
+
+  it('should log success message when cache is restored', async () => {
+    await handleGetCache();
+    expect(success).toHaveBeenCalledWith(
+      'Cache restored. Cache ID: %s',
+      mockCacheResult.cacheId
+    );
+  });
+
+  const testCacheNotFoundError = async (continueOnCacheMiss: boolean) => {
+    (mockConfig.values as CacheCommandConfig & CacheGetCommandConfig).continue =
+      continueOnCacheMiss;
+    const axiosError = { response: { status: 404 } };
+    vi.mocked(isAxiosError).mockReturnValue(true);
+    vi.mocked(retrieveCache).mockResolvedValueOnce(mockCacheResult);
+    vi.mocked(download).mockRejectedValue(axiosError);
+
+    if (continueOnCacheMiss) {
+      await handleGetCache();
+      expect(warnWithNoTrace).toHaveBeenCalledWith(
+        `Cache with ID "${mockCacheResult.cacheId}" not found`
+      );
+    } else {
+      await expect(handleGetCache()).rejects.toThrow(
+        `Cache with ID "${mockCacheResult.cacheId}" not found`
+      );
+      expect(warnWithNoTrace).not.toHaveBeenCalled();
+    }
+  };
+
+  it('should throw an error if cache is not found and continueOnCacheMiss is false', async () => {
+    await testCacheNotFoundError(false);
+  });
+
+  it('should warn and return if cache is not found and continueOnCacheMiss is true', async () => {
+    await testCacheNotFoundError(true);
+  });
+
+  it('should throw an unknown error if it is not an Axios error', async () => {
+    const unknownError = new Error('Unknown error');
+    vi.mocked(download).mockRejectedValue(unknownError);
+    await expect(handleGetCache()).rejects.toThrow(unknownError);
+  });
+});

--- a/packages/cmd/src/services/cache/__tests__/set.spec.ts
+++ b/packages/cmd/src/services/cache/__tests__/set.spec.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCache } from '../../../api';
+import { PRESETS } from '../../../commands/cache/options';
+import {
+  CacheCommandConfig,
+  CacheSetCommandConfig,
+  getCacheCommandConfig,
+} from '../../../config/cache';
+import { getCI } from '../../../env/ciProvider';
+import { success } from '../../../logger';
+import { filterPaths, zipFilesToBuffer } from '../fs';
+import { createMeta, getLastRunFilePath } from '../lib';
+import { sendBuffer } from '../network';
+import { handleSetCache } from '../set';
+
+vi.mock('../../../config/cache');
+vi.mock('../../../env/ciProvider');
+vi.mock('../../../api');
+vi.mock('../../../logger');
+vi.mock('../fs');
+vi.mock('../lib');
+vi.mock('../network');
+
+describe('handleSetCache', () => {
+  const mockConfig: {
+    type: 'SET_COMMAND_CONFIG';
+    values: CacheCommandConfig & CacheSetCommandConfig;
+  } = {
+    type: 'SET_COMMAND_CONFIG',
+    values: {
+      recordKey: 'testKey',
+      id: 'testId',
+      preset: PRESETS.lastRun,
+      pwOutputDir: 'outputDir',
+      matrixIndex: 0,
+      matrixTotal: 1,
+      path: ['file1', 'file2'],
+    },
+  };
+
+  const mockCI: ReturnType<typeof getCI> = {
+    provider: 'testCI',
+    ciBuildId: { source: 'random', value: 'auto-ci-build-id' },
+    params: {},
+  };
+
+  const mockCreateCacheResult = {
+    cacheId: 'cacheId123',
+    uploadUrl: 'http://upload.url',
+    metaUploadUrl: 'http://meta.url',
+    orgId: 'org123',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getCacheCommandConfig).mockReturnValue(mockConfig);
+    vi.mocked(getCI).mockReturnValue(mockCI);
+    vi.mocked(createCache).mockResolvedValue(mockCreateCacheResult);
+    vi.mocked(zipFilesToBuffer).mockResolvedValue(Buffer.from('zip archive'));
+    vi.mocked(createMeta).mockReturnValue(Buffer.from('meta data'));
+    vi.mocked(getLastRunFilePath).mockReturnValue('.last-run.json');
+  });
+
+  it('should throw an error if config type is not SET_COMMAND_CONFIG', async () => {
+    vi.mocked(getCacheCommandConfig).mockReturnValue({
+      type: 'GET_COMMAND_CONFIG',
+      values: mockConfig.values,
+    });
+    await expect(handleSetCache()).rejects.toThrow('Config is missing!');
+  });
+
+  it('should throw an error if config values are not set', async () => {
+    vi.mocked(getCacheCommandConfig).mockReturnValue({
+      type: 'GET_COMMAND_CONFIG',
+      values: null,
+    });
+    await expect(handleSetCache()).rejects.toThrow('Config is missing!');
+  });
+
+  it('should throw an error if no paths available to upload', async () => {
+    vi.mocked(getCacheCommandConfig).mockReturnValue({
+      ...mockConfig,
+      values: { ...mockConfig.values, preset: undefined, path: [] },
+    });
+    await expect(handleSetCache()).rejects.toThrow(
+      'No paths available to upload'
+    );
+  });
+
+  it('should call filterPaths and zipFilesToBuffer', async () => {
+    await handleSetCache();
+    expect(filterPaths).toHaveBeenCalledWith(mockConfig.values.path);
+    expect(zipFilesToBuffer).toHaveBeenCalledWith(['.last-run.json']);
+  });
+
+  it('should upload cache archive and meta data', async () => {
+    await handleSetCache();
+
+    expect(createCache).toHaveBeenCalledWith({
+      recordKey: 'testKey',
+      ci: mockCI,
+      id: 'testId',
+      config: { matrixIndex: 0, matrixTotal: 1 },
+    });
+
+    expect(sendBuffer).toHaveBeenCalledWith(
+      {
+        buffer: Buffer.from('zip archive'),
+        contentType: 'application/zip',
+        name: 'cacheId123',
+        uploadUrl: 'http://upload.url',
+      },
+      'application/zip',
+      undefined
+    );
+
+    expect(sendBuffer).toHaveBeenCalledWith(
+      {
+        buffer: Buffer.from('meta data'),
+        contentType: 'application/json',
+        name: 'cacheId123_meta',
+        uploadUrl: 'http://meta.url',
+      },
+      'application/json',
+      undefined
+    );
+  });
+
+  it('should log success message when cache is uploaded', async () => {
+    await handleSetCache();
+    expect(success).toHaveBeenCalledWith(
+      'Cache uploaded. Cache ID: %s',
+      'cacheId123'
+    );
+  });
+
+  it('should call getLastRunFilePath if preset is lastRun', async () => {
+    await handleSetCache();
+    expect(getLastRunFilePath).toHaveBeenCalledWith('outputDir');
+  });
+
+  it('should throw error if handleArchiveUpload fails', async () => {
+    vi.mocked(zipFilesToBuffer).mockRejectedValue(
+      new Error('Failed to zip files')
+    );
+    await expect(handleSetCache()).rejects.toThrow('Failed to zip files');
+  });
+
+  it('should throw error if handleMetaUpload fails', async () => {
+    vi.mocked(sendBuffer).mockRejectedValue(new Error('Failed to uplaod'));
+    await expect(handleSetCache()).rejects.toThrow('Failed to uplaod');
+  });
+});

--- a/packages/cmd/src/services/cache/set.ts
+++ b/packages/cmd/src/services/cache/set.ts
@@ -21,7 +21,9 @@ export async function handleSetCache() {
   const { recordKey, id, preset, pwOutputDir, matrixIndex, matrixTotal } =
     config.values;
 
-  const paths = config.values.path ? filterPaths(config.values.path) : [];
+  const paths = config.values.path?.length
+    ? filterPaths(config.values.path)
+    : [];
 
   const uploadPaths: string[] = [];
 


### PR DESCRIPTION
Changes:
- the cache commands will always exit with status code > 0 on error
- updated the `error` function to show error stack only in debug mode
- updated the `warnWithNoTrace` function to show error stack only in debug mode
- implemented the `--continue` flag for `cache get` command. When passed, the `cache get` command will not fail if the cache was not found, displaying a warning
- [x] available beta with the changes - [1.1.2-beta.0](https://www.npmjs.com/package/@currents/cmd/v/1.1.2-beta.0)
- [x] updated workflows, added `--continue` flag to `cache get` command
  - https://github.com/vCaisim/playwright-gh-actions-demo/tree/main/.github/workflows
  - [x] tested workflows
  - [x] update GitLab pipelines
- [x] updated GHA template to call `cache get` command with `--continue` flag
  - https://github.com/vCaisim/playwright-last-failed v1.0.11
  - [x] tested workflows