### PR TITLE
[CSR-1799] feat: added junit originFramework support

### DIFF
--- a/packages/cmd/src/api/create-run.ts
+++ b/packages/cmd/src/api/create-run.ts
@@ -29,7 +29,7 @@ export type Framework = {
   type: string;
   clientVersion: string | null;
   version: string | null;
-  frameworkConfig: FrameworkConfig;
+  frameworkConfig?: FrameworkConfig;
 };
 
 export type FrameworkConfig = {

--- a/packages/cmd/src/services/upload/index.ts
+++ b/packages/cmd/src/services/upload/index.ts
@@ -97,7 +97,14 @@ export async function handleCurrentsReport() {
     type: config.framework,
     version: config.frameworkVersion,
     clientVersion: reporterVersion,
-    frameworkConfig: config.frameworkConfig,
+    frameworkConfig: {
+      originFramework: config.frameworkConfig?.originFramework as
+        | string
+        | undefined,
+      originFrameworkVersion: config.frameworkConfig?.originFrameworkVersion as
+        | string
+        | undefined,
+    },
   };
 
   const machineId = nanoid.userFacingNanoid();


### PR DESCRIPTION
## Description

> Provide a brief description of the changes in this PR. Important to list all the changes made in overall. Describe any improvements, follow up tasks or edge cases related to this PR

This PR introduces support for sending to Currents API `frameworkConfig.originFramework` and  `frameworkConfig.originFrameworkVersion` for being used in the context of JUnit reporting.
The `framework` type now will have `frameworkConfig` property with `originFramework?: string;` and `originFrameworkVersion?: string;` properties.
These properties are taken from the `config.json` file.

## PR Checklist

- [x] I performed manual tests or added tests that prove my fix is effective or that my feature works.
- [x] I have performed a self-review of my code.
- [x] I have annotated my PR with comments, particularly in hard-to-understand areas.
- [x] I have considered the security implications of this work.

## Release Plan

> Do we need to update any environment variables? Is there any order of releases required?

- Package release

## Demo

> Add screenshots or videos demonstrating the solution if applicable

<img width="794" alt="image" src="https://github.com/user-attachments/assets/210b8c3d-a3de-4df3-b7f3-95898a46f6a8">

<img width="811" alt="image" src="https://github.com/user-attachments/assets/c35dba27-b252-41cc-9839-5543aa6fe115">

<img width="921" alt="image" src="https://github.com/user-attachments/assets/a24b930a-8667-448b-bf99-b473877f758a">


## Manual Testing

> Describe in steps (support it with images if needed) how to try the changes of this PR. (Even the start/setup of the services needed to try it out). If it's a bug also include reproduction steps

1. Create a vitest/postman/wdio testing suite example (or use the [existing example repository](https://github.com/currents-dev/currents-junit-xml-example))
2. In your JUnit XML report director `config.json` file add `originFramework: "vitest"` and `originFrameworkVersion: "1.0.2"`. The values of the properties can be any string but in the dashboard we [start recognizing on this PR](https://github.com/currents-dev/currents/compare/feat/junit-originframework-support?expand=1) only `vitest`, `postman` and `wdio` values.
3. Generate the instance files, and execute the `currents upload` command to send the results.
4. You should see the specific logo of the `originFramework` you set, if is not a recognized value, it will fall into the `junit` value.
