### PR TITLE
[CSR-1878] fix: jest attempt fields

### DIFF
--- a/packages/jest/src/lib/test.ts
+++ b/packages/jest/src/lib/test.ts
@@ -125,7 +125,7 @@ export function jestStatusFromInvocations(testResults: TestCaseResult[]) {
 }
 
 export function getAttemptNumber(result: TestCaseResult) {
-  return result?.invocations ?? 1;
+  return (result?.invocations ?? 1) - 1;
 }
 
 // Test that has "passed" and "failed" invocations is `'flaky'`

--- a/packages/jest/src/types.ts
+++ b/packages/jest/src/types.ts
@@ -54,10 +54,10 @@ export type InstanceReportTestAttempt = {
   duration: number;
   status: TestRunnerStatus;
 
-  stderr?: string[];
-  stdout?: string[];
+  stderr: string[];
+  stdout: string[];
 
-  errors?: ErrorSchema[];
+  errors: ErrorSchema[];
   error?: ErrorSchema;
 };
 


### PR DESCRIPTION
Changes:

- make `attempt` start from `0`
- set `stderr`, `stdout` and `error` array fields required

[Screencast from 2024-11-22 17-16-43.webm](https://github.com/user-attachments/assets/3c2507a6-e48b-423e-87c8-126876c8b81c)

:warning:  Required deploy for `@currents/jest`