### PR TITLE
[CSR-1905] fix: add missing dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13905,6 +13905,7 @@
         "async-retry": "^1.3.3",
         "axios": "^1.7.2",
         "axios-retry": "^4.4.0",
+        "chalk": "^4.1.2",
         "commander": "^11.1.0",
         "debug": "^4.3.5",
         "dotenv": "^16.4.5",

--- a/packages/cmd/package.json
+++ b/packages/cmd/package.json
@@ -45,6 +45,7 @@
     "async-retry": "^1.3.3",
     "axios": "^1.7.2",
     "axios-retry": "^4.4.0",
+    "chalk": "^4.1.2",
     "commander": "^11.1.0",
     "debug": "^4.3.5",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
Changes:
- add `chalk` as dependency for `@currents/cmd` package