### PR TITLE
[CSR-1942] fix: add ensureArray to full test suite discovery, avoid creating testless instance files

### DIFF
--- a/packages/cmd/src/services/convert/postman/instances.ts
+++ b/packages/cmd/src/services/convert/postman/instances.ts
@@ -25,7 +25,7 @@ export async function getInstanceMap(
   }
 
   const testsuites = ensureArray<TestSuite>(
-    parsedXMLInput.testsuites.testsuite
+    parsedXMLInput.testsuites?.testsuite
   );
 
   const groupId = parsedXMLInput.testsuites.name;
@@ -33,7 +33,11 @@ export async function getInstanceMap(
   testsuites.forEach((suite: TestSuite) => {
     const suiteJson = createSuiteJson(suite, groupId);
     const fileNameHash = generateShortHash(suite?.name ?? '');
-    instances.set(fileNameHash, suiteJson);
+    
+    // Avoid creating testless instance files as the full test suite won't have it
+    if (suiteJson.results.tests.length !== 0) {
+      instances.set(fileNameHash, suiteJson);
+    }
   });
 
   return instances;

--- a/packages/cmd/src/services/upload/discovery/junit/scanner.ts
+++ b/packages/cmd/src/services/upload/discovery/junit/scanner.ts
@@ -4,8 +4,13 @@ import { debug as _debug } from '@debug';
 import { dim, error } from '@logger';
 import { join } from 'path';
 import { parseStringPromise } from 'xml2js';
-import { TestSuites } from '../../../../services/convert/types';
 import {
+  TestCase,
+  TestSuite,
+  TestSuites,
+} from '../../../../services/convert/types';
+import {
+  ensureArray,
   generateTestId,
   getSpec,
   getTestTitle,
@@ -43,7 +48,7 @@ export async function jUnitScanner(reportDir: string) {
 function parseToFullTestSuite(jsonContent: TestSuites) {
   const fullTestSuite: FullTestSuite = [];
 
-  const testsuites = jsonContent.testsuites?.testsuite;
+  const testsuites = ensureArray<TestSuite>(jsonContent.testsuites?.testsuite);
 
   const fullSuiteProject: FullSuiteProject = {
     name: jsonContent.testsuites?.name ?? 'No name',
@@ -52,7 +57,7 @@ function parseToFullTestSuite(jsonContent: TestSuites) {
   };
 
   testsuites?.forEach((suite) => {
-    const testcases = suite?.testcase;
+    const testcases = ensureArray<TestCase>(suite?.testcase);
 
     testcases?.forEach((testcase) => {
       const fullSuiteTest: FullSuiteTest = {


### PR DESCRIPTION
## Description

> Provide a brief description of the changes in this PR. Important to list all the changes made in overall. Describe any improvements, follow up tasks or edge cases related to this PR

This PR adds the ensureArray function to the upload command for junit discovery phase. Also avoids creating instace files with no tests in the convert command.

## PR Checklist

- [x] I performed manual tests or added tests that prove my fix is effective or that my feature works.
- [x] I have performed a self-review of my code.
- [x] I have annotated my PR with comments, particularly in hard-to-understand areas.
- [x] I have considered the security implications of this work.

## Release Plan

- Release new package version

## Demo

https://www.loom.com/share/ea57bd328ed64d9eb84745110805044c?sid=c70986c5-52a9-40b1-a408-9cc317036e06

## Manual test

Bug
- Create a postman junit xml file with testsuite tag with no testcase on it
- With the current version of `currents-reporter`, use the convert command to generate the instances
- Then use the upload command to create the fulltestsuite and report to currents
- It should show a bunch of non found test in cache and also a run that will timeout eventually

Solution
- Create a postman junit xml file with testsuite tag with no testcase on it
- With this branch changes of `currents-reporter`, use the convert command to generate the instances
- Then use the upload command to create the fulltestsuite and report to currents
- It should show a completed run