### PR TITLE
[CSR-1964] fix: upload command options parsing

### DIFF
--- a/packages/cmd/src/config/upload/env.ts
+++ b/packages/cmd/src/config/upload/env.ts
@@ -62,9 +62,9 @@ export function getEnvVariables(): Partial<
     tag: process.env[configKeys.tag.env]
       ? process.env[configKeys.tag.env]?.split(',').map((i) => i.trim())
       : undefined,
-    disableTitleTags: !!process.env[configKeys.disableTitleTags.env],
-    removeTitleTags: !!process.env[configKeys.removeTitleTags.env],
-    debug: !!process.env[configKeys.debug.env],
+    disableTitleTags: process.env[configKeys.disableTitleTags.env],
+    removeTitleTags: process.env[configKeys.removeTitleTags.env],
+    debug: process.env[configKeys.debug.env],
     machineId: process.env[configKeys.machineId.env],
   };
 }


### PR DESCRIPTION
The incorrect environment variable parsing was overwriting the command options parsing. Reference - https://github.com/currents-dev/currents-reporter/blob/7d945a2e5076a5fb70c2aedeb6a8db2333f7773d/packages/cmd/src/config/utils.ts#L49

Testing the options:
[Screencast from 2024-12-11 16-54-47.webm](https://github.com/user-attachments/assets/55afffd9-3504-4eff-9f52-f0c92c4a9bf0)

Running with debug:
![image](https://github.com/user-attachments/assets/0f418d74-e5bb-49b1-966f-80f1c86d62c7)
