### PR TITLE
[CSR-1976] fix: change getSuiteName

### DIFF
--- a/packages/cmd/src/services/convert/__tests__/utils.test.ts
+++ b/packages/cmd/src/services/convert/__tests__/utils.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { getSuiteName } from '../utils';
+
+describe('getSuiteName', () => {
+  it.each([
+    [
+      'returns file name when no duplicates',
+      { file: 'testFile.js', id: '1' },
+      [{ file: 'testFile.js', id: '2' }],
+      undefined,
+      'testFile.js',
+    ],
+    [
+      'appends id to file name when file is duplicate',
+      { file: 'testFile.js', id: '1' },
+      [
+        { file: 'testFile.js', id: '1' },
+        { file: 'testFile.js', id: '2' },
+      ],
+      undefined,
+      'testFile.js - 1',
+    ],
+    [
+      'appends index to file name when file is duplicate, id is duplicate, and index is provided',
+      { file: 'testFile.js', id: '1' },
+      [
+        { file: 'testFile.js', id: '1' },
+        { file: 'testFile.js', id: '1' },
+      ],
+      1,
+      'testFile.js - 1',
+    ],
+
+    [
+      'returns the file name when file is duplicate, id is duplicate, and index is 0',
+      { file: 'testFile.js', id: '1' },
+      [
+        { file: 'testFile.js', id: '1' },
+        { file: 'testFile.js', id: '1' },
+      ],
+      0,
+      'testFile.js',
+    ],
+
+    [
+      'returns name when no duplicates',
+      { name: 'testSuite', id: '1' },
+      [{ name: 'testSuite', id: '2' }],
+      undefined,
+      'testSuite',
+    ],
+    [
+      'appends id to name when name is duplicate',
+      { name: 'testSuite', id: '1' },
+      [
+        { name: 'testSuite', id: '1' },
+        { name: 'testSuite', id: '2' },
+      ],
+      undefined,
+      'testSuite - 1',
+    ],
+    [
+      'appends index to name when name is duplicate, id is duplicate, and index is provided',
+      { name: 'testSuite', id: '1' },
+      [
+        { name: 'testSuite', id: '1' },
+        { name: 'testSuite', id: '1' },
+      ],
+      1,
+      'testSuite - 1',
+    ],
+
+    [
+      'returns the name when name is duplicate, id is duplicate, and index is 0',
+      { name: 'testSuite', id: '1' },
+      [
+        { name: 'testSuite', id: '1' },
+        { name: 'testSuite', id: '1' },
+      ],
+      0,
+      'testSuite',
+    ],
+
+    [
+      'returns id when no file or name is present',
+      { id: '1' },
+      [{ id: '2' }],
+      undefined,
+      '1',
+    ],
+    [
+      'appends index to id when id is duplicate and index is provided',
+      { id: '1' },
+      [{ id: '1' }, { id: '1' }],
+      2,
+      '1 - 2',
+    ],
+    [
+      'returns the id when id is duplicate and index is 0',
+      { id: '1' },
+      [{ id: '1' }, { id: '1' }],
+      0,
+      '1',
+    ],
+
+    [
+      'returns "unknown - index" when no file, name, or id is present, and index is provided',
+      {},
+      [],
+      2,
+      'unknown - 2',
+    ],
+    [
+      'returns "unknown" when no file, name, or id is present and no index is provided',
+      {},
+      [],
+      undefined,
+      'unknown',
+    ],
+  ])('%s', (_, suite, allSuites, index, expected) => {
+    expect(getSuiteName(suite, allSuites, index)).toBe(expected);
+  });
+});

--- a/packages/cmd/src/services/convert/postman/instances.ts
+++ b/packages/cmd/src/services/convert/postman/instances.ts
@@ -30,8 +30,8 @@ export async function getInstanceMap(
 
   const groupId = parsedXMLInput.testsuites.name;
 
-  testsuites.forEach((suite: TestSuite) => {
-    const suiteName = getSuiteName(suite, testsuites);
+  testsuites.forEach((suite: TestSuite, index) => {
+    const suiteName = getSuiteName(suite, testsuites, index);
     const suiteJson = createSuiteJson(suite, groupId, suiteName);
     const fileNameHash = generateShortHash(suiteName);
 

--- a/packages/cmd/src/services/convert/utils.ts
+++ b/packages/cmd/src/services/convert/utils.ts
@@ -7,6 +7,7 @@ import {
   TestRunnerStatus,
 } from '../../types';
 import { Failure, TestCase, TestSuite } from './types';
+import { isNumber } from 'lodash';
 
 export function getTestCase(
   testCase: TestCase,
@@ -181,21 +182,70 @@ export function timeToMilliseconds(time?: string): number {
   return secondsToMilliseconds(parseFloat(time ?? '0'));
 }
 
-export function getSuiteName(currentSuite: TestSuite, allSuites: TestSuite[]) {
-  // There can be multiple testsuite with the same name but includes an ID to identify
-  const suiteIndex = allSuites.findIndex(
-    (item) => item.name === currentSuite.name
-  );
-  if (!currentSuite.file && suiteIndex !== -1) {
-    if (!currentSuite.id && !currentSuite.name) {
-      return suiteIndex.toString();
+/**
+ * Generates a unique suite name based on the provided suite and allSuites array.
+ * The priority for the suite name is as follows:
+ * 1. `file` property of the suite.
+ * 2. `name` property of the suite.
+ * 3. `id` property of the suite.
+ * 4. If none of the above properties are available, it returns 'unknown'.
+ *
+ * If there are duplicates in the `allSuites` array based on the selected property,
+ * it appends the `id` or `index` to the suite name to ensure uniqueness.
+ *
+ * @param suite - The test suite object.
+ * @param allSuites - Array of all test suites.
+ * @param index - Optional index to include in the suite name for uniqueness.
+ * @returns The generated suite name.
+ */
+export function getSuiteName(
+  suite: TestSuite,
+  allSuites: TestSuite[],
+  index?: number
+) {
+  const includeIndex = isNumber(index) && index > 0;
+  const hasDuplicateId = !!suite.id && hasDuplicate(allSuites, 'id', suite.id);
+
+  if (suite.file) {
+    const hasDuplicateFile = hasDuplicate(allSuites, 'file', suite.file);
+
+    if (hasDuplicateFile && !hasDuplicateId) {
+      return `${suite.file} - ${suite.id}`;
     }
-    return currentSuite.id + ' / ' + currentSuite.name;
+    if (hasDuplicateFile && includeIndex) {
+      return `${suite.file} - ${index}`;
+    }
+    return suite.file;
   }
 
-  if (currentSuite.file) {
-    return currentSuite.file;
+  if (suite.name) {
+    const hasDuplicateName = hasDuplicate(allSuites, 'name', suite.name);
+
+    if (hasDuplicateName && !hasDuplicateId) {
+      return `${suite.name} - ${suite.id}`;
+    }
+    if (hasDuplicateName && includeIndex) {
+      return `${suite.name} - ${index}`;
+    }
+    return suite.name;
   }
 
-  return currentSuite.name ?? '';
+  if (suite.id) {
+    if (hasDuplicateId && includeIndex) {
+      return `${suite.id} - ${index}`;
+    }
+    return suite.id;
+  }
+
+  if (includeIndex) {
+    return `unknown - ${index}`;
+  }
+  return 'unknown';
+}
+
+function hasDuplicate<T>(arr: T[], property: string, value: unknown) {
+  const filtered = arr.filter(
+    (obj) => (obj as Record<string, unknown>)[property] === value
+  );
+  return filtered.length > 1;
 }


### PR DESCRIPTION
Changes:
- modify `getSuiteName` to try and generate a unique suite name based on existing suite fields.

Check the unit tests:

```bash
cd packages/cmd

npm run test
```

Example:
[Screencast from 2024-12-16 13-12-28.webm](https://github.com/user-attachments/assets/c7ce2ec3-df93-4eb4-8d6e-a81ed9205e9d)
