### PR TITLE
[CSR-2011] feat: allow reporting instance results in different requests

### DIFF
--- a/packages/cmd/src/api/create-run.ts
+++ b/packages/cmd/src/api/create-run.ts
@@ -84,7 +84,6 @@ export async function createRun(params: CreateRunParams) {
   try {
     debug('Run params: %o', maskRecordKey(params));
     const data = await compressData(JSON.stringify(params));
-    console.log('PAYLOAD::', JSON.stringify(params));
 
     return makeRequest<CreateRunResponse, Buffer>(ClientType.API, {
       url: `v1/runs`,

--- a/packages/cmd/src/api/create-run.ts
+++ b/packages/cmd/src/api/create-run.ts
@@ -63,7 +63,7 @@ export type CreateRunParams = {
   commit: Commit;
   tags: string[];
   ci: CI;
-  fullTestSuite: FullTestSuite;
+  fullTestSuite?: FullTestSuite;
   instances: InstanceReport[];
   config: RunCreationConfig;
 };
@@ -84,6 +84,7 @@ export async function createRun(params: CreateRunParams) {
   try {
     debug('Run params: %o', maskRecordKey(params));
     const data = await compressData(JSON.stringify(params));
+    console.log('PAYLOAD::', JSON.stringify(params));
 
     return makeRequest<CreateRunResponse, Buffer>(ClientType.API, {
       url: `v1/runs`,

--- a/packages/cmd/src/services/upload/utils.ts
+++ b/packages/cmd/src/services/upload/utils.ts
@@ -1,0 +1,33 @@
+export const sizeof = (value: unknown): number => {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+};
+
+export const splitArrayIntoChunks = <T>(
+  array: T[],
+  maxSizeInBytes: number = 10 * 1024 * 1024
+): T[][] => {
+  const chunks: T[][] = [];
+  let currentChunk: T[] = [];
+  let currentChunkSize = 0;
+
+  for (const item of array) {
+    const itemSize = sizeof(item);
+
+    // If adding the item exceeds the max size, push the current chunk and start a new one
+    if (currentChunkSize + itemSize > maxSizeInBytes) {
+      chunks.push(currentChunk);
+      currentChunk = [];
+      currentChunkSize = 0;
+    }
+
+    currentChunk.push(item);
+    currentChunkSize += itemSize;
+  }
+
+  // Push the last chunk if it has items
+  if (currentChunk.length > 0) {
+    chunks.push(currentChunk);
+  }
+
+  return chunks;
+};

--- a/packages/cmd/src/services/upload/utils.ts
+++ b/packages/cmd/src/services/upload/utils.ts
@@ -4,7 +4,7 @@ export const sizeof = (value: unknown): number => {
 
 export const splitArrayIntoChunks = <T>(
   array: T[],
-  maxSizeInBytes: number = 10 * 1024 * 1024
+  maxSizeInBytes: number = 1 * 1024 * 1024
 ): T[][] => {
   const chunks: T[][] = [];
   let currentChunk: T[] = [];


### PR DESCRIPTION
## Description

> Provide a brief description of the changes in this PR. Important to list all the changes made in overall. Describe any improvements, follow up tasks or edge cases related to this PR

This PR allows dividing the reporting of the instance results into multiple requests. Initially it is dividing the results if the array is more than 1MB in 1MB max parts.
The fullTestSuite is only part of the first createRun request.

IMPORTANT NOTE: While doing the tests with a really big amount of spec files (about 2k) and after some minutes after the run finished, I'm seeing this behavior:
<img width="1422" alt="image" src="https://github.com/user-attachments/assets/62bafe61-c2ca-448f-8fff-80bf87503eef" />
<img width="1485" alt="image" src="https://github.com/user-attachments/assets/4b4980ae-6bf1-4e61-88b0-58840e8aa486" />

This is much likely related to the redis OOM issue (CSR-1967). Checked with DJ this and it seems to be that, but we'll have to wait until those changes are merged and working to check again if this issue shows up again.

## PR Checklist

- [x] I performed manual tests or added tests that prove my fix is effective or that my feature works.
- [x] I have performed a self-review of my code.
- [x] I have annotated my PR with comments, particularly in hard-to-understand areas.
- [x] I have considered the security implications of this work.

## Release Plan

> Do we need to update any environment variables? Is there any order of releases required?

- Package release

## Demo

> Add screenshots or videos demonstrating the solution if applicable

https://www.loom.com/share/d547d24c6b16401a8178b5d8f5ad780a?sid=e03781a0-b548-4bc3-a980-c2884eb2d46e

## Manual Testing

> Describe in steps (support it with images if needed) how to try the changes of this PR. (Even the start/setup of the services needed to try it out). If it's a bug also include reproduction steps

1. Generate an XML file with at least 2MB of tests
2. Use the convert command to create the instance files
3. Use the upload command to report the results
