### PR TITLE
[CSR-2086] fix: use the rootDir on fs.realpathSync

### DIFF
--- a/packages/jest/src/lib/error.ts
+++ b/packages/jest/src/lib/error.ts
@@ -154,7 +154,7 @@ export function formatError(
       if (
         // @ts-ignore
         !error.snippet &&
-        (!file || fs.realpathSync(file) !== location.file)
+        (!file || fs.realpathSync(`${rootDir}/${file}`) !== location.file)
       ) {
         tokens.push('');
         tokens.push(

--- a/packages/jest/src/lib/error.ts
+++ b/packages/jest/src/lib/error.ts
@@ -20,7 +20,7 @@ import path from 'path';
 import StackUtils from 'stack-utils';
 import url from 'url';
 import { ErrorSchema, LocationSchema } from '../types';
-import debug from 'debug';
+import { debug } from '../lib/debug';
 
 function parseErrorString(errorString: string) {
   // Remove ANSI escape codes for easier parsing

--- a/packages/jest/src/lib/error.ts
+++ b/packages/jest/src/lib/error.ts
@@ -20,6 +20,7 @@ import path from 'path';
 import StackUtils from 'stack-utils';
 import url from 'url';
 import { ErrorSchema, LocationSchema } from '../types';
+import debug from 'debug';
 
 function parseErrorString(errorString: string) {
   // Remove ANSI escape codes for easier parsing
@@ -151,16 +152,20 @@ export function formatError(
     location = parsed.location;
     if (location) {
       // Convert /var/folders to /private/var/folders on Mac.
-      if (
-        // @ts-ignore
-        !error.snippet &&
-        (!file || fs.realpathSync(`${rootDir}/${file}`) !== location.file)
-      ) {
-        tokens.push('');
-        tokens.push(
-          chalk.gray(`   at `) +
-            `${relativeFilePath(rootDir, location.file)}:${location.line}`
-        );
+      try {
+        if (
+          // @ts-ignore
+          !error.snippet &&
+          (!file || fs.realpathSync(`${rootDir}/${file}`) !== location.file)
+        ) {
+          tokens.push('');
+          tokens.push(
+            chalk.gray(`   at `) +
+              `${relativeFilePath(rootDir, location.file)}:${location.line}`
+          );
+        }
+      } catch (e) {
+        debug(`No file found: ${JSON.stringify(e)}`);
       }
       tokens.push('');
       // @ts-ignore
@@ -181,6 +186,7 @@ export function formatError(
         }
       }
     }
+
     tokens.push('');
     tokens.push(parsed.stackLines.join('\n'));
   } else if (error.message) {


### PR DESCRIPTION
## Description

> Provide a brief description of the changes in this PR. Important to list all the changes made in overall. Describe any improvements, follow up tasks or edge cases related to this PR

This PR fixes the use of `fs.realpathSync` in the `formatError` function. It was causing the spec files to be searched in the root folder and was omitting searching in the specified `rootDir`.
This was causing the error: `TypeError: Cannot read properties of undefined (reading 'testCaseList')` and not generating the proper instance files required for reporting all the results.

## PR Checklist

- [x] I performed manual tests or added tests that prove my fix is effective or that my feature works.
- [x] I have performed a self-review of my code.
- [x] I have annotated my PR with comments, particularly in hard-to-understand areas.
- [x] I have considered the security implications of this work.

## Release Plan

- [x] I have added `release:<service>` labels to this PR

- What is the release order of the affected services? N/A
- What infrastructure changes are requires? N/A

## Demo

> Add screenshots or videos demonstrating the solution if applicable

https://www.loom.com/share/0be7681d74fb4023938972d92b6badba?sid=2491326b-6614-4340-88d1-714d5c49fd87

## Manual Testing

> Describe in steps (support it with images if needed) how to try the changes of this PR. (Even the start/setup of the services needed to try it out). If it's a bug also include reproduction steps

To reproduce:
1. Add to the `jest.config.js` file the property `rootDir: "./tests"` and add a couple spec files in that folder. At least of the tests should fail intentionally.
2. Execute your tests with the current published version of jest reporter.
3. You should get the error `TypeError: Cannot read properties of undefined (reading 'testCaseList')`

To test the fix:
1. Do the first 2 steps of the previous section
2. You should see your instance files properly generated.
