### PR TITLE
[CSR-2187] feat: support wdio framework, separate each instance map framework

### DIFF
--- a/packages/cmd/src/commands/convert/options.ts
+++ b/packages/cmd/src/commands/convert/options.ts
@@ -28,6 +28,7 @@ export const outputDirOption = new Option(
 export enum REPORT_FRAMEWORKS {
   postman = 'postman',
   vitest = 'vitest',
+  wdio = 'wdio'
 }
 export const frameworkOption = new Option(
   '--framework <string>',

--- a/packages/cmd/src/services/convert/getInstanceMap.ts
+++ b/packages/cmd/src/services/convert/getInstanceMap.ts
@@ -6,6 +6,8 @@ import {
 import { InstanceReport } from '../../types';
 import { getInstanceMap as getInstanceMapForPostman } from './postman/instances';
 import { TestSuites } from './types';
+import { getInstanceMap as getInstanceMapForVitest } from './vitest/instances';
+import { getInstanceMap as getInstanceMapForWdio } from './wdio/instances';
 
 export async function getInstanceMap({
   inputFormat,
@@ -28,10 +30,12 @@ async function getInstanceMapByFramework(
   parsedXMLArray: TestSuites[]
 ) {
   switch (framework) {
-    case 'postman':
+    case REPORT_FRAMEWORKS.postman:
       return getInstanceMapForPostman(parsedXMLArray);
-    case 'vitest':
-      return getInstanceMapForPostman(parsedXMLArray);
+    case REPORT_FRAMEWORKS.vitest:
+      return getInstanceMapForVitest(parsedXMLArray);
+    case REPORT_FRAMEWORKS.wdio:
+      return getInstanceMapForWdio(parsedXMLArray);
     default:
       warn('Unsupported framework: %s', framework);
       return new Map<string, InstanceReport>();

--- a/packages/cmd/src/services/convert/vitest/index.ts
+++ b/packages/cmd/src/services/convert/vitest/index.ts
@@ -1,0 +1,1 @@
+export * from './instances';

--- a/packages/cmd/src/services/convert/vitest/instances.ts
+++ b/packages/cmd/src/services/convert/vitest/instances.ts
@@ -1,0 +1,3 @@
+import { getInstanceMap } from '../postman';
+
+export { getInstanceMap };

--- a/packages/cmd/src/services/convert/wdio/index.ts
+++ b/packages/cmd/src/services/convert/wdio/index.ts
@@ -1,0 +1,1 @@
+export * from './instances';

--- a/packages/cmd/src/services/convert/wdio/instances.ts
+++ b/packages/cmd/src/services/convert/wdio/instances.ts
@@ -1,0 +1,3 @@
+import { getInstanceMap } from '../postman';
+
+export { getInstanceMap };


### PR DESCRIPTION
## Description

> Provide a brief description of the changes in this PR. Important to list all the changes made in overall. Describe any improvements, follow up tasks or edge cases related to this PR

This PR adds support for Webdriver.io framework in the cmd package.

## PR Checklist

- [x] I performed manual tests or added tests that prove my fix is effective or that my feature works.
- [x] I have performed a self-review of my code.
- [x] I have annotated my PR with comments, particularly in hard-to-understand areas.
- [x] I have considered the security implications of this work.

## Release Plan

- [x] I have added `release:<service>` labels to this PR

- What is the release order of the affected services? Package release
- What infrastructure changes are requires? N/A

## Demo

> Add screenshots or videos demonstrating the solution if applicable

https://github.com/user-attachments/assets/ac75c2c4-b9af-4ac8-819c-9892ace39b9d


## Manual Testing

> Describe in steps (support it with images if needed) how to try the changes of this PR. (Even the start/setup of the services needed to try it out). If it's a bug also include reproduction steps

- Run wdio tests using `wdio run`

```sh
npx wdio run ./wdio.conf.js
```

- Combine the report files using the combine script
Wdio will generate one JUnit XML file per spec file (Two files in this example) and must be combined as it belongs to the same group.

```sh
node ../../scripts/combineResults.js
```

This will generate a file named `combined-results.xml` with the combined results of all the spec files.

- Convert the combined JUnit XML test results to Currents-compatible format

```sh
npx currents convert \
  --input-format=junit \
  --input-file=combined-results.xml \
  --framework=wdio \
  --framework-version=v11.2.0
```

- Upload the results to Currents

```sh
npx currents upload --key=your-record-key --project-id=currents-project-id
```
