### PR TITLE
[CSR-2397] feat: request ciBuildId from server when not provided by client

### DIFF
--- a/packages/cmd/src/api/cache.ts
+++ b/packages/cmd/src/api/cache.ts
@@ -23,7 +23,7 @@ export type CacheCreationResponse = {
   orgId: string;
   uploadUrl: string;
   metaUploadUrl: string;
-  ciBuildId?: string;
+  ciBuildId?: string | null;
 };
 
 export type CacheRetrievalResponse = {

--- a/packages/cmd/src/api/cache.ts
+++ b/packages/cmd/src/api/cache.ts
@@ -15,6 +15,7 @@ export type CacheRequestParams = {
   ci: Record<string, unknown>;
   id?: string;
   config?: CacheRequestConfigParams;
+  withCiBuildId?: boolean;
 };
 
 export type CacheCreationResponse = {
@@ -22,6 +23,7 @@ export type CacheCreationResponse = {
   orgId: string;
   uploadUrl: string;
   metaUploadUrl: string;
+  ciBuildId?: string;
 };
 
 export type CacheRetrievalResponse = {

--- a/packages/cmd/src/services/cache/__tests__/set.spec.ts
+++ b/packages/cmd/src/services/cache/__tests__/set.spec.ts
@@ -129,6 +129,7 @@ describe('handleSetCache', () => {
       ci: mockCI,
       id: 'testId',
       config: { matrixIndex: 0, matrixTotal: 1 },
+      withCiBuildId: false,
     });
 
     expect(sendBuffer).toHaveBeenCalledWith(
@@ -151,6 +152,36 @@ describe('handleSetCache', () => {
       },
       'application/json',
       undefined
+    );
+  });
+
+  it('should request the ciBuildId from server and write it to meta file', async () => {
+    const localCI: ReturnType<typeof getCI> = {
+      ...mockCI,
+      ciBuildId: { source: 'server', value: null },
+    };
+    vi.mocked(getCI).mockReturnValue(localCI);
+    vi.mocked(createCache).mockResolvedValue({
+      ...mockCreateCacheResult,
+      ciBuildId: 'mockCiBuildId',
+    });
+    await handleSetCache();
+
+    expect(createCache).toHaveBeenCalledWith({
+      recordKey: 'testKey',
+      ci: localCI,
+      id: 'testId',
+      config: { matrixIndex: 0, matrixTotal: 1 },
+      withCiBuildId: true,
+    });
+
+    expect(createMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ci: {
+          ...localCI,
+          ciBuildId: { source: 'server', value: 'mockCiBuildId' },
+        },
+      })
     );
   });
 

--- a/packages/cmd/src/services/cache/set.ts
+++ b/packages/cmd/src/services/cache/set.ts
@@ -55,8 +55,13 @@ export async function handleSetCache() {
       matrixIndex,
       matrixTotal,
     },
+    withCiBuildId: ci.ciBuildId.source === 'server',
   });
   debug('Cache upload url created', { result });
+
+  if (result.ciBuildId) {
+    ci.ciBuildId.value = result.ciBuildId;
+  }
 
   if (uploadPaths.length > 0) {
     await handleArchiveUpload({


### PR DESCRIPTION
Changes:
- call "cache set" api endpoint with `withCiBuildId: true` when `ci.ciBuildId.source === 'server'`
- add returned `ciBuildId` from the server to `ci.ciBuildId.value` so it will be written to the meta file