### PR TITLE
[CSR-2474] chore: change url for get run request

### DIFF
--- a/packages/cmd/src/api/get-run.ts
+++ b/packages/cmd/src/api/get-run.ts
@@ -26,7 +26,7 @@ export async function getRun(apiKey: string, params: GetRunParams) {
     debug('Run params: %o', params);
 
     return makeRequest<GetRunResponse>(ClientType.REST_API, {
-      url: `v1/runs/previous`,
+      url: `v1/runs/find`,
       params,
       method: 'GET',
       headers: {


### PR DESCRIPTION
Changes:
- the endpoint URL for "get run" request, used by `npx currents-cli api get-run` command, was changed to `/v1/runs/find`

:warning: the new version should be released before [this PR](https://github.com/currents-dev/currents/pull/1318) is merged and `api lambda` released. 