### PR TITLE
[CSR-2397] fix: omit ciBuildId from cache meta file when null

### DIFF
--- a/packages/cmd/src/services/cache/__tests__/set.spec.ts
+++ b/packages/cmd/src/services/cache/__tests__/set.spec.ts
@@ -154,6 +154,24 @@ describe('handleSetCache', () => {
     );
   });
 
+  it('should omit ci.ciBuildId from meta when null', async () => {
+    const localCI: ReturnType<typeof getCI> = {
+      ...mockCI,
+      ciBuildId: { source: 'server', value: null },
+    };
+    vi.mocked(getCI).mockReturnValue(localCI);
+    await handleSetCache();
+
+    expect(createMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ci: {
+          ...localCI,
+          ciBuildId: undefined,
+        },
+      })
+    );
+  });
+
   it('should log success message when cache is uploaded', async () => {
     await handleSetCache();
     expect(success).toHaveBeenCalledWith(

--- a/packages/cmd/src/services/cache/set.ts
+++ b/packages/cmd/src/services/cache/set.ts
@@ -1,5 +1,6 @@
 import { debug } from '@debug';
 
+import { omit } from 'lodash';
 import { createCache } from '../../api';
 import { PRESETS } from '../../commands/cache/options';
 import { getCacheCommandConfig } from '../../config/cache';
@@ -72,7 +73,8 @@ export async function handleSetCache() {
     meta: createMeta({
       cacheId: result.cacheId,
       config: config.values,
-      ci,
+      // Exclude ciBuildId from meta if it's null
+      ci: ci.ciBuildId.value ? ci : omit(ci, 'ciBuildId'),
       orgId: result.orgId,
       path: uploadPaths,
     }),


### PR DESCRIPTION
Changes:
- exclude `ciBuildId` from cache meta file when it's value is `null`