### PR TITLE
[CSR-2470] fix: api get-run params validation

### DIFF
--- a/packages/cmd/src/config/api/__tests__/apiGetRunCustomValidation.spec.ts
+++ b/packages/cmd/src/config/api/__tests__/apiGetRunCustomValidation.spec.ts
@@ -1,0 +1,99 @@
+import { ValidationError } from '@lib';
+import { error } from '@logger';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  APICommandConfig,
+  APIGetRunCommandConfig,
+  apiGetRunCustomValidation,
+} from '../config';
+
+vi.mock('@logger', () => ({
+  error: vi.fn(),
+}));
+
+const baseConfig: APICommandConfig & APIGetRunCommandConfig = {
+  apiKey: 'api-key',
+  projectId: 'project-id',
+};
+
+describe('apiGetRunCustomValidation', () => {
+  it('should pass: only ciBuildId', () => {
+    expect(() =>
+      apiGetRunCustomValidation({
+        ...baseConfig,
+        ciBuildId: 'ci-123',
+      })
+    ).not.toThrow();
+  });
+
+  it('should pass: only tag', () => {
+    expect(() =>
+      apiGetRunCustomValidation({
+        ...baseConfig,
+        tag: ['smoke'],
+      })
+    ).not.toThrow();
+  });
+
+  it('should pass: only branch', () => {
+    expect(() =>
+      apiGetRunCustomValidation({
+        ...baseConfig,
+        branch: 'main',
+      })
+    ).not.toThrow();
+  });
+
+  it('should pass: tag and branch without ciBuildId', () => {
+    expect(() =>
+      apiGetRunCustomValidation({
+        ...baseConfig,
+        tag: ['beta'],
+        branch: 'develop',
+      })
+    ).not.toThrow();
+  });
+
+  it('should fail: missing all ciBuildId, tag, branch', () => {
+    expect(() =>
+      apiGetRunCustomValidation({
+        ...baseConfig,
+      })
+    ).toThrow(ValidationError);
+    expect(error).toHaveBeenCalledWith(
+      '"ciBuildId", "tag", "branch" or a combination of "tag" and "branch" are expected to be provided'
+    );
+  });
+
+  it('should fail: ciBuildId and tag together', () => {
+    expect(() =>
+      apiGetRunCustomValidation({
+        ...baseConfig,
+        ciBuildId: 'ci-1',
+        tag: ['v2'],
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it('should fail: all three provided', () => {
+    expect(() =>
+      apiGetRunCustomValidation({
+        ...baseConfig,
+        ciBuildId: 'ci-1',
+        tag: ['v1'],
+        branch: 'main',
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it('should fail: tag and branch but also ciBuildId', () => {
+    expect(() =>
+      apiGetRunCustomValidation({
+        ...baseConfig,
+        tag: ['v1'],
+        branch: 'dev',
+        ciBuildId: 'ci-2',
+      })
+    ).toThrow(ValidationError);
+  });
+});

--- a/packages/cmd/src/config/utils.ts
+++ b/packages/cmd/src/config/utils.ts
@@ -52,7 +52,8 @@ export function getValidatedConfig<T extends ConfigKeys, R>(
   getEnvVariables: () => Partial<
     Record<keyof R, string | string[] | boolean | number | undefined>
   >,
-  options?: Partial<R>
+  options?: Partial<R>,
+  customValidation?: (config: R) => void
 ) {
   const result = {
     ...removeUndefined(options),
@@ -72,6 +73,10 @@ export function getValidatedConfig<T extends ConfigKeys, R>(
       throw new ValidationError('Missing required config variable');
     }
   });
+
+  if (typeof customValidation === 'function') {
+    customValidation(result as R);
+  }
 
   return result as R;
 }

--- a/packages/cmd/src/http/httpErrors.ts
+++ b/packages/cmd/src/http/httpErrors.ts
@@ -66,6 +66,11 @@ function handle4xx<T, D>(
         data
       );
     })
+    .with(404, () => {
+      log.warn(
+        `[currents] ${error.response?.config.method} ${error.response?.config.url} - 404 Not Found from cloud service`,
+      );
+    })
     .with(429, () => {
       log.warn(
         `[currents] ${error.response?.config.method} ${error.response?.config.url} - 429 Too Many Requests from cloud service`


### PR DESCRIPTION
Changes:
- update `getValidatedConfig` to accept a custom validation function as argument
- add client side validation for `api get-run` command
![image](https://github.com/user-attachments/assets/39691af6-25ac-493f-b996-94b60a8907c3)

- fix formatting for 404 http errors
![image](https://github.com/user-attachments/assets/7015e1a1-1427-4f08-be35-bc8e1cd13cef)
