### PR TITLE
[CSR-2398] feat: cache history

### DIFF
--- a/packages/cmd/src/api/cache.ts
+++ b/packages/cmd/src/api/cache.ts
@@ -22,6 +22,8 @@ export type CacheCreationResponse = {
   orgId: string;
   uploadUrl: string;
   metaUploadUrl: string;
+  historyUploadUrl: string;
+  historyMetaUploadUrl: string;
 };
 
 export type CacheRetrievalResponse = {

--- a/packages/cmd/src/commands/cache/index.ts
+++ b/packages/cmd/src/commands/cache/index.ts
@@ -6,6 +6,7 @@ import {
   continueGetOption,
   continueSetOption,
   debugOption,
+  saveToHistoryOption,
   idOption,
   matrixIndexOption,
   matrixTotalOption,
@@ -65,6 +66,7 @@ export const getCacheSetCommand = () => {
     .addOption(matrixIndexOption)
     .addOption(matrixTotalOption)
     .addOption(continueSetOption)
+    .addOption(saveToHistoryOption)
     .action(getCacheSetHandler);
 
   return command;

--- a/packages/cmd/src/commands/cache/options.ts
+++ b/packages/cmd/src/commands/cache/options.ts
@@ -82,3 +82,8 @@ export const continueSetOption = new Option(
   '--continue',
   'Continue the script execution if upload paths are not found'
 ).default(false);
+
+export const saveToHistoryOption = new Option(
+  '--save-to-history',
+  'Save the uploaded cache to history for debugging purposes'
+).default(false);

--- a/packages/cmd/src/config/cache/config.ts
+++ b/packages/cmd/src/config/cache/config.ts
@@ -57,14 +57,21 @@ let _config:
 export function setCacheSetCommandConfig(
   options?: Partial<NonNullable<(typeof _config)['values']>>
 ) {
+  const values = getValidatedConfig(
+    configKeys,
+    mandatoryConfigKeys,
+    getEnvVariables,
+    options
+  );
+
+  const isDebugEnabled = values.debug || !!process.env.DEBUG;
+
   _config = {
     type: 'SET_COMMAND_CONFIG',
-    values: getValidatedConfig(
-      configKeys,
-      mandatoryConfigKeys,
-      getEnvVariables,
-      options
-    ),
+    values: {
+      ...values,
+      saveToHistory: isDebugEnabled ? true : values.saveToHistory,
+    },
   };
   debug('Resolved config: %o', {
     ..._config,

--- a/packages/cmd/src/config/cache/config.ts
+++ b/packages/cmd/src/config/cache/config.ts
@@ -30,6 +30,7 @@ export type CacheSetCommandConfig = CacheCommandConfig &
     path?: string[];
     pwOutputDir?: string;
     continue?: boolean;
+    saveToHistory?: boolean;
   };
 
 export type CacheGetCommandConfig = CacheCommandConfig &

--- a/packages/cmd/src/config/cache/options.ts
+++ b/packages/cmd/src/config/cache/options.ts
@@ -31,5 +31,6 @@ export function cacheSetCommandOptsToConfig(
     matrixIndex: options.matrixIndex,
     matrixTotal: options.matrixTotal,
     continue: options.continue,
+    saveToHistory: options.saveToHistory,
   };
 }

--- a/packages/cmd/src/services/cache/__tests__/set.spec.ts
+++ b/packages/cmd/src/services/cache/__tests__/set.spec.ts
@@ -168,8 +168,7 @@ describe('handleSetCache', () => {
     await handleSetCache();
 
     expect(sendBuffer).toHaveBeenCalledTimes(4);
-    expect(sendBuffer).toHaveBeenNthCalledWith(
-      3,
+    expect(sendBuffer).toHaveBeenCalledWith(
       {
         buffer: Buffer.from('zip archive'),
         contentType: 'application/zip',
@@ -179,8 +178,7 @@ describe('handleSetCache', () => {
       'application/zip',
       undefined
     );
-    expect(sendBuffer).toHaveBeenNthCalledWith(
-      4,
+    expect(sendBuffer).toHaveBeenCalledWith(
       {
         buffer: Buffer.from('meta data'),
         contentType: 'application/json',

--- a/packages/cmd/src/services/cache/__tests__/set.spec.ts
+++ b/packages/cmd/src/services/cache/__tests__/set.spec.ts
@@ -50,6 +50,8 @@ describe('handleSetCache', () => {
     cacheId: 'cacheId123',
     uploadUrl: 'http://upload.url',
     metaUploadUrl: 'http://meta.url',
+    historyUploadUrl: 'http://upload-123.url',
+    historyMetaUploadUrl: 'http://meta-123.url',
     orgId: 'org123',
   };
 
@@ -148,6 +150,42 @@ describe('handleSetCache', () => {
         contentType: 'application/json',
         name: 'cacheId123_meta',
         uploadUrl: 'http://meta.url',
+      },
+      'application/json',
+      undefined
+    );
+  });
+
+  it('should upload history cache and meta data', async () => {
+    vi.mocked(getCacheCommandConfig).mockReturnValue({
+      type: 'SET_COMMAND_CONFIG',
+      values: {
+        ...mockConfig.values,
+        saveToHistory: true,
+      },
+    });
+
+    await handleSetCache();
+
+    expect(sendBuffer).toHaveBeenCalledTimes(4);
+    expect(sendBuffer).toHaveBeenNthCalledWith(
+      3,
+      {
+        buffer: Buffer.from('zip archive'),
+        contentType: 'application/zip',
+        name: 'cacheId123',
+        uploadUrl: mockCreateCacheResult.historyUploadUrl,
+      },
+      'application/zip',
+      undefined
+    );
+    expect(sendBuffer).toHaveBeenNthCalledWith(
+      4,
+      {
+        buffer: Buffer.from('meta data'),
+        contentType: 'application/json',
+        name: 'cacheId123_meta',
+        uploadUrl: mockCreateCacheResult.historyMetaUploadUrl,
       },
       'application/json',
       undefined


### PR DESCRIPTION
Changes:
- add `--save-to-history` option for `cache set` command
- update `CacheCreationResponse` interface to include history upload URLs
- upload the cache to history URLs when `--save-to-history` option is set

Simplified solution - https://www.notion.so/currents/Cache-overrides-previous-reruns-1c0be2b5c1d580baaf0ee14a1bdf8f00?pvs=4#1d9be2b5c1d5801f9dcbe2b3a6ba6e32