### PR TITLE
[CSR-2398] feat: refactor cache commands implementation

### DIFF
--- a/packages/cmd/src/api/cache.ts
+++ b/packages/cmd/src/api/cache.ts
@@ -17,18 +17,32 @@ export type CacheRequestParams = {
   config?: CacheRequestConfigParams;
 };
 
+export type CacheReadUrlsRequestParams = {
+  recordKey: string;
+  cacheKey: string;
+  metaCacheKey?: string;
+};
+
 export type CacheCreationResponse = {
   cacheId: string;
   orgId: string;
   uploadUrl: string;
   metaUploadUrl: string;
+  cacheKey: string;
+  metaCacheKey: string;
+  refMetaUploadUrl: string;
 };
 
 export type CacheRetrievalResponse = {
   cacheId: string;
   orgId: string;
+  refMetaReadUrl: string;
+};
+
+export type CacheReadUrlsResponse = {
+  orgId: string;
   readUrl: string;
-  metaReadUrl: string;
+  metaReadUrl?: string;
 };
 
 export async function createCache(params: CacheRequestParams) {
@@ -56,13 +70,33 @@ export async function retrieveCache(params: CacheRequestParams) {
     return makeRequest<CacheRetrievalResponse, CacheRequestParams>(
       ClientType.API,
       {
-        url: 'cache/download',
+        url: 'cache/v2/download',
         method: 'POST',
         data: params,
       }
     ).then((res) => res.data);
   } catch (err) {
     debug('Failed to retrieve cache:', err);
+    throw err;
+  }
+}
+
+export async function retrieveCacheReadUrls(
+  params: CacheReadUrlsRequestParams
+) {
+  try {
+    debug('Request params: %o', params);
+
+    return makeRequest<CacheReadUrlsResponse, CacheReadUrlsRequestParams>(
+      ClientType.API,
+      {
+        url: 'cache/meta',
+        method: 'POST',
+        data: params,
+      }
+    ).then((res) => res.data);
+  } catch (err) {
+    debug('Failed to retrieve cache read URLs:', err);
     throw err;
   }
 }

--- a/packages/cmd/src/api/cache.ts
+++ b/packages/cmd/src/api/cache.ts
@@ -17,7 +17,7 @@ export type CacheRequestParams = {
   config?: CacheRequestConfigParams;
 };
 
-export type CacheReadUrlsRequestParams = {
+export type CacheRetrievalParams = {
   recordKey: string;
   cacheKey: string;
   metaCacheKey?: string;
@@ -33,13 +33,13 @@ export type CacheCreationResponse = {
   refMetaUploadUrl: string;
 };
 
-export type CacheRetrievalResponse = {
+export type CacheMetaResponse = {
   cacheId: string;
   orgId: string;
   refMetaReadUrl: string;
 };
 
-export type CacheReadUrlsResponse = {
+export type CacheRetrievalResponse = {
   orgId: string;
   readUrl: string;
   metaReadUrl?: string;
@@ -63,11 +63,11 @@ export async function createCache(params: CacheRequestParams) {
   }
 }
 
-export async function retrieveCache(params: CacheRequestParams) {
+export async function retrieveCache(params: CacheRetrievalParams) {
   try {
     debug('Request params: %o', params);
 
-    return makeRequest<CacheRetrievalResponse, CacheRequestParams>(
+    return makeRequest<CacheRetrievalResponse, CacheRetrievalParams>(
       ClientType.API,
       {
         url: 'cache/v2/download',
@@ -81,22 +81,17 @@ export async function retrieveCache(params: CacheRequestParams) {
   }
 }
 
-export async function retrieveCacheReadUrls(
-  params: CacheReadUrlsRequestParams
-) {
+export async function getRefCacheMeta(params: CacheRequestParams) {
   try {
     debug('Request params: %o', params);
 
-    return makeRequest<CacheReadUrlsResponse, CacheReadUrlsRequestParams>(
-      ClientType.API,
-      {
-        url: 'cache/meta',
-        method: 'POST',
-        data: params,
-      }
-    ).then((res) => res.data);
+    return makeRequest<CacheMetaResponse, CacheRequestParams>(ClientType.API, {
+      url: 'cache/meta',
+      method: 'POST',
+      data: params,
+    }).then((res) => res.data);
   } catch (err) {
-    debug('Failed to retrieve cache read URLs:', err);
+    debug('Failed to retrieve reference cache meta:', err);
     throw err;
   }
 }

--- a/packages/cmd/src/http/client.ts
+++ b/packages/cmd/src/http/client.ts
@@ -3,6 +3,7 @@ import axiosRetry from 'axios-retry';
 import _ from 'lodash';
 
 import { debug as _debug } from '../debug';
+import { reporterVersion } from '../env/versions';
 import { getAPIBaseUrl, getRestAPIBaseUrl, getTimeout } from './httpConfig';
 import {
   getDelay,
@@ -44,18 +45,9 @@ export function createClient(type: ClientType) {
     // @ts-ignore
     const retry = config['axios-retry']?.retryCount ?? 0;
 
-    // const currentsConfig = getCurrentsConfig();
-    // config.headers.set({
-    //   ...headers,
-    //   "x-currents-idempotency-key":
-    //     config.headers["x-currents-idempotency-key"] ?? nanoid(),
-    //   "x-jest-request-attempt": retry,
-    //   "x-currents-key": currentsConfig?.recordKey ?? null,
-    // });
-
-    // if (currentsConfig?.machineId) {
-    //   config.headers.set("x-currents-machine-id", currentsConfig.machineId);
-    // }
+    config.headers.set({
+      'x-cmd-version': reporterVersion,
+    });
 
     if (!config.headers.get('Content-Type')) {
       config.headers.set('Content-Type', 'application/json');

--- a/packages/cmd/src/services/cache/get.ts
+++ b/packages/cmd/src/services/cache/get.ts
@@ -90,7 +90,7 @@ async function handleArchiveDownload({
 
   await unzipBuffer(buffer, destination);
 
-  info('Cache downloaded', { readUrl, destination });
+  debug('Cache downloaded', { readUrl, destination });
   return destination;
 }
 
@@ -104,6 +104,6 @@ function getOutputDir(outputDir: string | undefined) {
 async function handleMetaDownload(readUrl: string) {
   const buffer = await download(readUrl);
   const meta = JSON.parse(buffer.toString('utf-8')) as RefMetaFile;
-  info('Meta file downloaded: %O', meta);
+  debug('Meta file downloaded: %O', meta);
   return meta;
 }

--- a/packages/cmd/src/services/cache/get.ts
+++ b/packages/cmd/src/services/cache/get.ts
@@ -1,6 +1,6 @@
 import { isAxiosError } from 'axios';
 import path from 'path';
-import { retrieveCache, retrieveCacheReadUrls } from '../../api';
+import { getRefCacheMeta, retrieveCache } from '../../api';
 import { PRESETS } from '../../commands/cache/options';
 import { getCacheCommandConfig } from '../../config/cache';
 import { getCI } from '../../env/ciProvider';
@@ -32,7 +32,7 @@ export async function handleGetCache() {
     await handlePreLastRunPreset(config.values, ci);
   }
 
-  const result = await retrieveCache({
+  const { cacheId, refMetaReadUrl } = await getRefCacheMeta({
     recordKey,
     ci,
     id,
@@ -43,9 +43,9 @@ export async function handleGetCache() {
   });
 
   try {
-    const meta = await handleMetaDownload(result.refMetaReadUrl);
+    const meta = await handleMetaDownload(refMetaReadUrl);
 
-    const { readUrl } = await retrieveCacheReadUrls({
+    const { readUrl } = await retrieveCache({
       recordKey,
       cacheKey: meta.cacheKey,
     });
@@ -60,11 +60,11 @@ export async function handleGetCache() {
     }
 
     info(dim('- restoring cache to'), destination);
-    success('Cache restored. Cache ID: %s', result.cacheId);
+    success('Cache restored. Cache ID: %s', cacheId);
   } catch (e) {
     if (isAxiosError(e)) {
       if (e.response?.status === 403 || e.response?.status === 404) {
-        const message = `Cache with ID "${result.cacheId}" not found`;
+        const message = `Cache with ID "${cacheId}" not found`;
         if (continueOnCacheMiss) {
           warnWithNoTrace(message);
           return;

--- a/packages/cmd/src/services/cache/get.ts
+++ b/packages/cmd/src/services/cache/get.ts
@@ -1,3 +1,4 @@
+import { debug } from '@debug';
 import { isAxiosError } from 'axios';
 import path from 'path';
 import { getRefCacheMeta, retrieveCache } from '../../api';

--- a/packages/cmd/src/services/cache/get.ts
+++ b/packages/cmd/src/services/cache/get.ts
@@ -1,13 +1,12 @@
-import { debug } from '@debug';
 import { isAxiosError } from 'axios';
 import path from 'path';
-import { retrieveCache } from '../../api';
+import { retrieveCache, retrieveCacheReadUrls } from '../../api';
 import { PRESETS } from '../../commands/cache/options';
 import { getCacheCommandConfig } from '../../config/cache';
 import { getCI } from '../../env/ciProvider';
 import { dim, info, success, warnWithNoTrace } from '../../logger';
 import { unzipBuffer } from './fs';
-import { MetaFile } from './lib';
+import { RefMetaFile } from './lib';
 import { download } from './network';
 import { handlePostLastRunPreset, handlePreLastRunPreset } from './presets';
 
@@ -44,12 +43,17 @@ export async function handleGetCache() {
   });
 
   try {
-    const destination = await handleArchiveDownload({
-      readUrl: result.readUrl,
-      outputDir,
+    const meta = await handleMetaDownload(result.refMetaReadUrl);
+
+    const { readUrl } = await retrieveCacheReadUrls({
+      recordKey,
+      cacheKey: meta.cacheKey,
     });
 
-    const meta = await handleMetaDownload(result.metaReadUrl);
+    const destination = await handleArchiveDownload({
+      readUrl,
+      outputDir,
+    });
 
     if (preset === PRESETS.lastRun) {
       await handlePostLastRunPreset(config.values, ci, meta);
@@ -86,7 +90,7 @@ async function handleArchiveDownload({
 
   await unzipBuffer(buffer, destination);
 
-  debug('Cache downloaded');
+  info('Cache downloaded', { readUrl, destination });
   return destination;
 }
 
@@ -99,7 +103,7 @@ function getOutputDir(outputDir: string | undefined) {
 
 async function handleMetaDownload(readUrl: string) {
   const buffer = await download(readUrl);
-  const meta = JSON.parse(buffer.toString('utf-8')) as MetaFile;
-  debug('Meta file: %O', meta);
+  const meta = JSON.parse(buffer.toString('utf-8')) as RefMetaFile;
+  info('Meta file downloaded: %O', meta);
   return meta;
 }

--- a/packages/cmd/src/services/cache/lib.ts
+++ b/packages/cmd/src/services/cache/lib.ts
@@ -11,19 +11,32 @@ export type MetaFile = {
   createdAt: string;
 };
 
+export type RefMetaKeys = {
+  cacheKey: string;
+  metaCacheKey: string;
+};
+
+export type RefMetaFile = MetaFile & RefMetaKeys;
+
+type CreateMetaParams = {
+  config: CacheSetCommandConfig;
+  cacheId: string;
+  orgId: string;
+  path: string[];
+  ci: Record<string, unknown>;
+  cacheKey?: string;
+  metaCacheKey?: string;
+};
+
 export function createMeta({
   config,
   cacheId,
   orgId,
   path,
   ci,
-}: {
-  config: CacheSetCommandConfig;
-  cacheId: string;
-  orgId: string;
-  path: string[];
-  ci: Record<string, unknown>;
-}) {
+  cacheKey,
+  metaCacheKey,
+}: CreateMetaParams) {
   const meta = {
     id: cacheId,
     orgId,
@@ -31,6 +44,8 @@ export function createMeta({
     path,
     ci,
     createdAt: new Date().toISOString(),
+    cacheKey,
+    metaCacheKey,
   };
 
   return Buffer.from(JSON.stringify(meta));

--- a/packages/cmd/src/services/cache/set.ts
+++ b/packages/cmd/src/services/cache/set.ts
@@ -73,7 +73,7 @@ export async function handleSetCache() {
         uploadUrl: result.uploadUrl,
       }).then(() => {
         logUploadPaths(uploadPaths);
-        info('Cache archive uploaded', {
+        debug('Cache archive uploaded', {
           uploadUrl: result.uploadUrl,
         });
       })
@@ -92,7 +92,7 @@ export async function handleSetCache() {
       cacheId: result.cacheId,
       uploadUrl: result.metaUploadUrl,
     }).then(() =>
-      info('Meta uploaded', {
+      debug('Meta uploaded', {
         uploadUrl: result.metaUploadUrl,
       })
     ),
@@ -109,7 +109,7 @@ export async function handleSetCache() {
       cacheId: result.cacheId,
       uploadUrl: result.refMetaUploadUrl,
     }).then(() =>
-      info('Ref meta uploaded', {
+      debug('Ref meta uploaded', {
         uploadUrl: result.refMetaUploadUrl,
       })
     )

--- a/packages/cmd/src/services/cache/set.ts
+++ b/packages/cmd/src/services/cache/set.ts
@@ -59,28 +59,63 @@ export async function handleSetCache() {
   });
   debug('Cache upload url created', { result });
 
-  if (uploadPaths.length > 0) {
-    await handleArchiveUpload({
-      archive: await zipFilesToBuffer(uploadPaths),
-      cacheId: result.cacheId,
-      uploadUrl: result.uploadUrl,
-    });
+  const ciForMeta = getCIForMeta(ci);
 
-    info(uploadPaths.map((path) => `${dim('- uploading')} ${path}`).join('\n'));
+  const archive =
+    uploadPaths.length > 0 ? await zipFilesToBuffer(uploadPaths) : null;
+  const uploads = [];
+
+  if (archive) {
+    uploads.push(
+      handleArchiveUpload({
+        archive,
+        cacheId: result.cacheId,
+        uploadUrl: result.uploadUrl,
+      }).then(() => {
+        logUploadPaths(uploadPaths);
+        info('Cache archive uploaded', {
+          uploadUrl: result.uploadUrl,
+        });
+      })
+    );
   }
 
-  await handleMetaUpload({
-    meta: createMeta({
+  uploads.push(
+    handleMetaUpload({
+      meta: createMeta({
+        cacheId: result.cacheId,
+        config: config.values,
+        ci: ciForMeta,
+        orgId: result.orgId,
+        path: uploadPaths,
+      }),
       cacheId: result.cacheId,
-      config: config.values,
-      ci: getCIForMeta(ci),
-      orgId: result.orgId,
-      path: uploadPaths,
-    }),
-    cacheId: result.cacheId,
-    uploadUrl: result.metaUploadUrl,
-  });
+      uploadUrl: result.metaUploadUrl,
+    }).then(() =>
+      info('Meta uploaded', {
+        uploadUrl: result.metaUploadUrl,
+      })
+    ),
+    handleMetaUpload({
+      meta: createMeta({
+        cacheId: result.cacheId,
+        config: config.values,
+        ci: ciForMeta,
+        orgId: result.orgId,
+        path: uploadPaths,
+        cacheKey: result.cacheKey,
+        metaCacheKey: result.metaCacheKey,
+      }),
+      cacheId: result.cacheId,
+      uploadUrl: result.refMetaUploadUrl,
+    }).then(() =>
+      info('Ref meta uploaded', {
+        uploadUrl: result.refMetaUploadUrl,
+      })
+    )
+  );
 
+  await Promise.all(uploads);
   success('Cache uploaded. Cache ID: %s', result.cacheId);
 }
 
@@ -147,4 +182,11 @@ function getCIForMeta(ci: ReturnType<typeof getCI>) {
   return ci.ciBuildId.source === 'server' || ci.ciBuildId.source === 'random'
     ? omit(ci, 'ciBuildId')
     : ci;
+}
+
+function logUploadPaths(paths: string[]) {
+  info(
+    `Cache upload paths:\n` +
+      paths.map((path) => `${dim('- uploading')} ${path}`).join('\n')
+  );
 }


### PR DESCRIPTION
Refactored version of cache commands using the approach described here - https://www.notion.so/Cache-overrides-previous-reruns-1c0be2b5c1d580baaf0ee14a1bdf8f00?d=1dcbe2b5c1d5809db602001c89554b9c&pvs=4#1d9be2b5c1d5805c8bb0e68c179d33d6

:warning: Depends on https://github.com/currents-dev/currents/pull/1359

Tested:
https://us-east-1.console.aws.amazon.com/s3/buckets/currents-staging.fs?region=us-east-1&bucketType=general&prefix=cache%2F67b46af1bb1acaff09f97589%2F&showversions=false&tab=objects

Note:

[28cacf8a_meta.json](https://us-east-1.console.aws.amazon.com/s3/object/currents-staging.fs?region=us-east-1&bucketType=general&prefix=cache/67b46af1bb1acaff09f97589/28cacf8a_meta.json) contains `cacheKey` and `metaCacheKey` keys which are used to obtained the signed urls for cache download.

