### PR TITLE
[CSR-2553] fix: Cache Run Attempts with GitLab

### DIFF
--- a/packages/cmd/src/services/cache/presets.ts
+++ b/packages/cmd/src/services/cache/presets.ts
@@ -85,7 +85,7 @@ async function dumpPwConfigForGitlab(
     config.presetOutput ?? PRESET_OUTPUT_PATH,
     `EXTRA_PW_FLAGS="${pwCliOptions}"
 EXTRA_PWCP_FLAGS="${lastFailedOption}"
-RUN_ATTEMPT="${runAttempt}"
+RUN_ATTEMPT=${runAttempt}
 `
   );
 }


### PR DESCRIPTION
- An upstream GitLab bug has broken Run Attempt handling

Starting in December, GitLab changed their handling of env variables, and broke compatibility with the `source` command. 

Bug logged here: https://gitlab.com/gitlab-org/gitlab-runner/-/issues/38776

Now when a env file uses quotes to wrap a variable, the quotes get re-exported to the environment. (meaning that `RUN_ATTEMPT="1"` becomes `RUN_ATTEMPT="\"1\""` . When the variable is just being printed (like being appended onto a command), it's not a problem, but if the variable is being used in any bash math,  OR being parsed by a program via the environment, it causes issues.


This PR removes the quotes around RUN_ATTEMPT to workaround the issue.