### PR TITLE
[CSR-2745] fix: report correct test status for jest reporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15457,7 +15457,7 @@
     },
     "packages/cmd": {
       "name": "@currents/cmd",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^12.1.0",

--- a/packages/jest/src/lib/test.ts
+++ b/packages/jest/src/lib/test.ts
@@ -1,5 +1,6 @@
 import { Test, TestCaseResult } from '@jest/reporters';
 import type { Circus } from '@jest/types';
+import { maxBy } from 'lodash';
 import crypto from 'node:crypto';
 import {
   ExpectedStatus,
@@ -106,13 +107,18 @@ export function getExpectedStatus(status: JestTestCaseStatus): ExpectedStatus {
   }
 }
 
-export function jestStatusFromInvocations(testResults: TestCaseResult[]) {
-  const statuses = testResults.map((r) => r.status as JestTestCaseStatus);
-  if (statuses.every((status) => status === statuses[0])) {
-    return statuses[0];
+export function jestStatusFromInvocations(
+  testResults: TestCaseResult[]
+): JestTestCaseStatus {
+  if (testResults.length === 0) {
+    return 'failed';
   }
 
-  return 'failed';
+  const resultWithMaxInvocation =
+    maxBy(testResults, (r) => r.invocations ?? 0) ??
+    testResults[testResults.length - 1];
+
+  return resultWithMaxInvocation.status as JestTestCaseStatus;
 }
 
 export function getAttemptNumber(result: TestCaseResult) {


### PR DESCRIPTION
A fix for the `jest` reporter: set the test status as the status of the last test result


https://github.com/user-attachments/assets/def26313-4fe2-4000-9de7-f2b2fbb308a5

