### PR TITLE
fix: use posix pathing to build last run file paths [CSR-3199]

### DIFF
--- a/packages/cmd/src/services/cache/path.ts
+++ b/packages/cmd/src/services/cache/path.ts
@@ -19,7 +19,9 @@ export const getUploadPaths = async (pathPatterns: string[] = []) => {
   const uploadPaths: string[] = [];
 
   if (filteredPaths.length > 0) {
-    uploadPaths.push(...globby.sync(pathPatterns));
+    uploadPaths.push(
+      ...globby.sync(pathPatterns.map((p) => p.replace(/\\/g, '/')))
+    );
   }
   return uploadPaths;
 };

--- a/packages/cmd/src/services/cache/path.ts
+++ b/packages/cmd/src/services/cache/path.ts
@@ -6,8 +6,8 @@ export const getLastRunFilePaths = async (outputPath?: string) => {
   const prefix = path.resolve(outputPath ?? './test-results');
 
   const patterns = [
-    path.resolve(prefix, '**/.last-run.json'),
-    path.resolve(prefix, '.last-run.json'),
+    path.posix.join(prefix.replace(/\\/g, '/'), '**/.last-run.json'),
+    path.posix.join(prefix.replace(/\\/g, '/'), '.last-run.json'),
   ];
 
   return globby.sync(patterns);


### PR DESCRIPTION
This PR fixes an issue where `.last-run.json` file wes not detected on Windows due to incorrect glob path formatting.

- replaced `path.resolve` with `path.posix.join` to ensure all glob patterns use forward slashes (`/`), which globby expects even on Windows

On Windows:
<img width="956" height="1241" alt="image" src="https://github.com/user-attachments/assets/a5c2860f-d1fc-4f5c-b84b-d0fb99fe0894" />

On Mac:
<img width="1137" height="702" alt="image" src="https://github.com/user-attachments/assets/97d3109f-9380-4eb0-946a-2a1a1b20ce2d" />
