### PR TITLE
chore: release @currents/cmd v1.9.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16829,7 +16829,7 @@
     },
     "packages/cmd": {
       "name": "@currents/cmd",
-      "version": "1.9.6",
+      "version": "1.9.7",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^12.1.0",

--- a/packages/cmd/CHANGELOG.md
+++ b/packages/cmd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.9.7](/compare/@currents/cmd-v1.9.6...${npm.name}-v1.9.7) (2026-03-16)
+
+
+### Bug Fixes
+
+* restore commonjs support for the cmd package 042159b
+
 ## [1.9.6](https://github.com/currents-dev/currents-reporter/compare/@currents/cmd-v1.9.5...${npm.name}-v1.9.6) (2026-03-12)
 
 

--- a/packages/cmd/CHANGELOG.md
+++ b/packages/cmd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.9.7](/compare/@currents/cmd-v1.9.6...${npm.name}-v1.9.7) (2026-03-16)
+## [1.9.7](https://github.com/currents-dev/currents-reporter/compare/@currents/cmd-v1.9.6...${npm.name}-v1.9.7) (2026-03-16)
 
 
 ### Bug Fixes

--- a/packages/cmd/package.json
+++ b/packages/cmd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@currents/cmd",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "main": "./dist/index.js",
   "author": {
     "name": "Currents Software Inc",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Published version 1.9.7 (2026-03-16) with updated changelog entry.
* **Bug Fixes**
  * Restored CommonJS support for the cmd package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->