### PR TITLE
Remove matrix/retry CI params from circle and gitlab provider detection

### DIFF
--- a/packages/cmd/src/env/ciProvider.ts
+++ b/packages/cmd/src/env/ciProvider.ts
@@ -252,13 +252,9 @@ const _providerCiParams = (): ProviderCiParamsRes => {
       'CIRCLE_PR_USERNAME',
       'CIRCLE_COMPARE_URL',
       'CIRCLE_WORKFLOW_ID',
-      'CIRCLE_WORKFLOW_WORKSPACE_ID',
       'CIRCLE_PULL_REQUEST',
       'CIRCLE_REPOSITORY_URL',
       'CI_PULL_REQUEST',
-      // matrix information
-      'CIRCLE_NODE_INDEX',
-      'CIRCLE_NODE_TOTAL',
     ]),
     codeshipBasic: extract([
       'CI_BUILD_ID',
@@ -319,9 +315,6 @@ const _providerCiParams = (): ProviderCiParamsRes => {
       'CI_JOB_ID',
       'CI_JOB_URL',
       'CI_JOB_NAME',
-      // matrix information
-      'CI_NODE_INDEX',
-      'CI_NODE_TOTAL',
       // other information
       'GITLAB_HOST',
       'CI_PROJECT_ID',
@@ -329,8 +322,6 @@ const _providerCiParams = (): ProviderCiParamsRes => {
       'CI_REPOSITORY_URL',
       'CI_ENVIRONMENT_URL',
       'CI_DEFAULT_BRANCH',
-      // custom variables
-      'RUN_ATTEMPT', // custom param that we ourselves sometimes add for retrying jobs
       // for PRs: https://gitlab.com/gitlab-org/gitlab-ce/issues/23902
     ]),
     // https://docs.gocd.org/current/faq/dev_use_current_revision_in_build.html#standard-gocd-environment-variables

--- a/packages/cmd/src/env/types.ts
+++ b/packages/cmd/src/env/types.ts
@@ -37,9 +37,6 @@ export type GitLabParams = {
   ciRepositoryUrl: string;
   ciEnvironmentUrl: string;
   ciDefaultBranch: string;
-  ciNodeIndex?: string;
-  ciNodeTotal?: string;
-  runAttempt?: string;
 };
 
 export type CircleParams = {
@@ -51,10 +48,7 @@ export type CircleParams = {
   circlePrUsername: string;
   circleCompareUrl: string;
   circleWorkflowId: string;
-  circleWorkflowWorkspaceId: string;
   circlePullRequest: string;
   circleRepositoryUrl: string;
   ciPullRequest: string;
-  circleNodeIndex: string;
-  circleNodeTotal: string;
 };

--- a/packages/cmd/src/services/cache/presets.ts
+++ b/packages/cmd/src/services/cache/presets.ts
@@ -57,14 +57,13 @@ async function dumpPwConfigForGitlab(
   ci: ReturnType<typeof getCI>,
   meta: MetaFile | null = null
 ) {
-  const ciParams = ci.params as GitLabParams;
   const prevCiParams = meta?.ci.params as null | GitLabParams;
   const prevRunAttempt = prevCiParams
-    ? parseIntSafe(prevCiParams.runAttempt, 0)
+    ? parseIntSafe((prevCiParams as any).runAttempt, 0)
     : 0;
   const runAttempt = prevRunAttempt + 1;
-  const nodeIndex = parseIntSafe(ciParams.ciNodeIndex, 1);
-  const jobTotal = parseIntSafe(ciParams.ciNodeTotal, 1);
+  const nodeIndex = parseIntSafe(process.env.CI_NODE_INDEX, 1);
+  const jobTotal = parseIntSafe(process.env.CI_NODE_TOTAL, 1);
 
   const wasPWExecuted = wasLastRunFileUploaded(meta);
   const isLastFailed = runAttempt > 1 && wasPWExecuted;
@@ -127,11 +126,11 @@ async function dumpPWConfigForCircle(
 
   const prevCiParams = meta?.ci.params as null | CircleParams;
   const prevWorkflowId = prevCiParams?.circleWorkflowId;
-  const prevWorkspaceId = prevCiParams?.circleWorkflowWorkspaceId;
-  const nodeIndex = parseIntSafe(ciParams.circleNodeIndex, 0);
-  const nodeTotal = parseIntSafe(ciParams.circleNodeTotal, 1);
+  const prevWorkspaceId = (prevCiParams as any)?.circleWorkflowWorkspaceId;
+  const nodeIndex = parseIntSafe(process.env.CIRCLE_NODE_INDEX, 0);
+  const nodeTotal = parseIntSafe(process.env.CIRCLE_NODE_TOTAL, 1);
   const isRerun =
-    prevWorkspaceId == ciParams.circleWorkflowWorkspaceId &&
+    prevWorkspaceId == process.env.CIRCLE_WORKFLOW_WORKSPACE_ID &&
     prevWorkflowId !== ciParams.circleWorkflowId;
 
   const wasPWExecuted = wasLastRunFileUploaded(meta);

--- a/turbo.json
+++ b/turbo.json
@@ -40,7 +40,14 @@
 
     "lint": {
       "outputs": [],
-      "env": ["CURRENTS_DISCOVERY_PATH"]
+      "env": [
+        "CURRENTS_DISCOVERY_PATH",
+        "CI_NODE_INDEX",
+        "CI_NODE_TOTAL",
+        "CIRCLE_NODE_INDEX",
+        "CIRCLE_NODE_TOTAL",
+        "CIRCLE_WORKFLOW_WORKSPACE_ID"
+      ]
     },
     "dev": {
       "cache": false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Aligns the ciProvider params that we detect and export with the changes made in [currents-playwright@d2bd16e](https://github.com/currents-dev/currents-playwright/commit/d2bd16e272eaf37bfb181168eafc7f672df4d13b).

## Changes

### `packages/cmd/src/env/ciProvider.ts`
- **circle**: Removed `CIRCLE_WORKFLOW_WORKSPACE_ID`, `CIRCLE_NODE_INDEX`, `CIRCLE_NODE_TOTAL` from `_providerCiParams`
- **gitlab**: Removed `CI_NODE_INDEX`, `CI_NODE_TOTAL`, `RUN_ATTEMPT` from `_providerCiParams`

### `packages/cmd/src/env/types.ts`
- **`CircleParams`**: Removed `circleWorkflowWorkspaceId`, `circleNodeIndex`, `circleNodeTotal` fields
- **`GitLabParams`**: Removed `ciNodeIndex`, `ciNodeTotal`, `runAttempt` fields

### `packages/cmd/src/services/cache/presets.ts`
- Updated `dumpPwConfigForGitlab` and `dumpPWConfigForCircle` to read matrix/retry env vars directly from `process.env` instead of from CI params, since these are no longer extracted into CI provider data

### `turbo.json`
- Added `CI_NODE_INDEX`, `CI_NODE_TOTAL`, `CIRCLE_NODE_INDEX`, `CIRCLE_NODE_TOTAL`, `CIRCLE_WORKFLOW_WORKSPACE_ID` to lint env allowlist for the new direct `process.env` references

## Verification
- Build passes
- Type checking passes
- Lint passes
- All 111 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5886598-9ab0-435c-8e2e-c59ed8b861da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5886598-9ab0-435c-8e2e-c59ed8b861da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

