### PR TITLE
fix(cmd): use .cjs extension for temp jest scanner config

### DIFF
--- a/packages/cmd/src/services/upload/discovery/jest/args/config.ts
+++ b/packages/cmd/src/services/upload/discovery/jest/args/config.ts
@@ -98,7 +98,7 @@ export async function getConfigFilePath(
 
     const tmpFilePath = path.resolve(
       configPath ? path.dirname(configPath) : process.cwd(),
-      `.jest-scanner-${new Date().getTime()}.config.js`
+      `.jest-scanner-${new Date().getTime()}.config.cjs`
     );
 
     const configFileContents = `module.exports=${JSON.stringify(parsedConfigObject, null, 2)}`;


### PR DESCRIPTION
## Summary

`getConfigFilePath` writes a temp jest config file at `.jest-scanner-${ts}.config.js` with CommonJS content (`module.exports=...`). In a project whose `package.json` declares `"type": "module"`, Node treats `.js` as ESM and the discovery step crashes with `ReferenceError: module is not defined in ES module scope`.

Renaming the temp file to `.cjs` forces CommonJS regardless of the ambient package type.

## Why this is safe

The file is purely internal:
- Created by `getConfigFilePath`
- Consumed by the spawned jest subprocess via `--config=<path>`
- Unlinked in the same `finally` block

No public API change, no user-facing artifact change.

## Repro

```sh
mkdir repro && cd repro
echo '{"type":"module"}' > package.json
# any jest config + run
npx @currents/cmd convert --framework=jest ...
```

Without the fix: `ReferenceError: module is not defined in ES module scope`.
With the fix: scanner runs to completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Jest configuration file handling to use an improved extension format, maintaining all existing functionality and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->