### PR TITLE
chore: integrate Linear Releases with multi-package workflow

### DIFF
--- a/.github/workflows/linear-release.yaml
+++ b/.github/workflows/linear-release.yaml
@@ -46,7 +46,8 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           # Format: @currents/PACKAGE_NAME-vVERSION
-          if [[ $TAG =~ ^@currents/([^-]+)-v(.+)$ ]]; then
+          # Use digit anchor to correctly capture multi-hyphen package names
+          if [[ $TAG =~ ^@currents/(.+)-v([0-9]+\..+)$ ]]; then
             PACKAGE="${BASH_REMATCH[1]}"
             VERSION="${BASH_REMATCH[2]}"
             echo "package=$PACKAGE" >> $GITHUB_OUTPUT

--- a/.github/workflows/linear-release.yaml
+++ b/.github/workflows/linear-release.yaml
@@ -1,0 +1,88 @@
+name: Linear Release
+
+on:
+  push:
+    tags:
+      - '@currents/cmd-v*'
+      - '@currents/jest-v*'
+      - '@currents/node-test-reporter-v*'
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  linear-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Main branch: sync to all package pipelines
+      - name: Sync main branch to Linear (cmd)
+        if: github.ref_type == 'branch' && github.ref_name == 'main'
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_CMD }}
+
+      - name: Sync main branch to Linear (jest)
+        if: github.ref_type == 'branch' && github.ref_name == 'main'
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_JEST }}
+
+      - name: Sync main branch to Linear (node-test-reporter)
+        if: github.ref_type == 'branch' && github.ref_name == 'main'
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_NODE_TEST_REPORTER }}
+
+      # Tag pushed: extract package name and version
+      - name: Extract package and version from tag
+        if: github.ref_type == 'tag'
+        id: extract_tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          # Format: @currents/PACKAGE_NAME-vVERSION
+          if [[ $TAG =~ ^@currents/([^-]+)-v(.+)$ ]]; then
+            PACKAGE="${BASH_REMATCH[1]}"
+            VERSION="${BASH_REMATCH[2]}"
+            echo "package=$PACKAGE" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+          else
+            echo "Error: Tag '$TAG' does not match expected format '@currents/PACKAGE-vVERSION'"
+            exit 1
+          fi
+
+      # Determine Linear access key based on package
+      - name: Set Linear access key
+        if: github.ref_type == 'tag'
+        id: linear_key
+        run: |
+          PACKAGE="${{ steps.extract_tag.outputs.package }}"
+          case "$PACKAGE" in
+            cmd)
+              echo "key=LINEAR_ACCESS_KEY_CMD" >> $GITHUB_OUTPUT
+              ;;
+            jest)
+              echo "key=LINEAR_ACCESS_KEY_JEST" >> $GITHUB_OUTPUT
+              ;;
+            node-test-reporter)
+              echo "key=LINEAR_ACCESS_KEY_NODE_TEST_REPORTER" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "Error: Unknown package '$PACKAGE'"
+              exit 1
+              ;;
+          esac
+
+      # Sync tag to Linear with package-specific key
+      - name: Sync tag to Linear
+        if: github.ref_type == 'tag'
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets[steps.linear_key.outputs.key] }}
+          version: ${{ steps.extract_tag.outputs.version }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -96,7 +96,8 @@ jobs:
         if: success() && github.event.inputs.channel == 'latest' && steps.release.outputs.release-url
         uses: slackapi/slack-github-action@v2
         with:
-          webhook-url: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "🚀 Release: ${{ github.event.inputs.package }}@${{ steps.extract_version.outputs.version }}",

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,8 +53,10 @@ jobs:
 
       - name: Extract package version
         id: extract_version
+        env:
+          PACKAGE_INPUT: ${{ github.event.inputs.package }}
         run: |
-          PACKAGE_SHORT_NAME=$(node -e "const m = JSON.parse('${{ env.PACKAGE_MAP }}'); console.log(m['${{ github.event.inputs.package }}'])")
+          PACKAGE_SHORT_NAME=$(node -e "const m = JSON.parse(process.env.PACKAGE_MAP); console.log(m[process.env.PACKAGE_INPUT])")
           PACKAGE_VERSION=$(node -p "require('./packages/$PACKAGE_SHORT_NAME/package.json').version")
           echo "version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
           echo "package_short=$PACKAGE_SHORT_NAME" >> $GITHUB_OUTPUT
@@ -80,6 +82,10 @@ jobs:
               ;;
             node-test-reporter)
               echo "key=LINEAR_ACCESS_KEY_NODE_TEST_REPORTER" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "Error: Unknown package '$PACKAGE_SHORT'"
+              exit 1
               ;;
           esac
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,14 @@ permissions:
   id-token: write  # Required for OIDC
   contents: read
 
+env:
+  PACKAGE_MAP: |
+    {
+      "@currents/cmd": "cmd",
+      "@currents/jest": "jest",
+      "@currents/node-test-reporter": "node-test-reporter"
+    }
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -43,9 +51,62 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Extract package version
+        id: extract_version
+        run: |
+          PACKAGE_SHORT_NAME=$(node -e "const m = JSON.parse('${{ env.PACKAGE_MAP }}'); console.log(m['${{ github.event.inputs.package }}'])")
+          PACKAGE_VERSION=$(node -p "require('./packages/$PACKAGE_SHORT_NAME/package.json').version")
+          echo "version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+          echo "package_short=$PACKAGE_SHORT_NAME" >> $GITHUB_OUTPUT
+
       - run: npm ci
       - name: Publish to NPM
         run: |
           git config user.name "Currents NPM Bot"
           git config user.email "npm@currents.dev"
           npm run publish:npm --workspace ${{ github.event.inputs.package }} -- --tag ${{ github.event.inputs.channel }}
+
+      - name: Determine Linear access key
+        id: linear_key
+        if: success() && github.event.inputs.channel == 'latest'
+        run: |
+          PACKAGE_SHORT="${{ steps.extract_version.outputs.package_short }}"
+          case "$PACKAGE_SHORT" in
+            cmd)
+              echo "key=LINEAR_ACCESS_KEY_CMD" >> $GITHUB_OUTPUT
+              ;;
+            jest)
+              echo "key=LINEAR_ACCESS_KEY_JEST" >> $GITHUB_OUTPUT
+              ;;
+            node-test-reporter)
+              echo "key=LINEAR_ACCESS_KEY_NODE_TEST_REPORTER" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Mark Linear release as complete
+        id: release
+        if: success() && github.event.inputs.channel == 'latest'
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets[steps.linear_key.outputs.key] }}
+          command: complete
+          version: ${{ steps.extract_version.outputs.version }}
+
+      - name: Post to Slack
+        if: success() && github.event.inputs.channel == 'latest' && steps.release.outputs.release-url
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          payload: |
+            {
+              "text": "🚀 Release: ${{ github.event.inputs.package }}@${{ steps.extract_version.outputs.version }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*🚀 Release: ${{ github.event.inputs.package }}@${{ steps.extract_version.outputs.version }}* has been marked as complete in Linear.\n\n<${{ steps.release.outputs.release-url }}|View Release Notes>"
+                  }
+                }
+              ]
+            }

--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ npm run release
 
 You can create a PR from the release branch to be merged after publish.
 
+### Linear Releases Integration
+
+The release process integrates with Linear Releases to track release scope, status, and changelog for each package:
+
+- **Main branch push:** When changes are pushed to main, they're automatically synced to the current started release in Linear for each respective package
+- **Release tag push:** When a release tag (e.g., `@currents/cmd-v1.9.10`) is pushed, all commits since the previous tag are scanned and synced to the corresponding Linear release pipeline
+- **Release completion:** When publishing to npm via the "Publish NPM Package" workflow with `latest` channel, the release is automatically marked as complete in Linear and posted to Slack
+
+When publishing to the latest channel, the workflow will:
+
+- Mark the release as complete in Linear using the package-specific pipeline access key
+- Post a release announcement to Slack with a link to view release notes in Linear
+
+**Required secrets:**
+
+- `LINEAR_ACCESS_KEY_CMD` — pipeline-scoped access key for @currents/cmd releases
+- `LINEAR_ACCESS_KEY_JEST` — pipeline-scoped access key for @currents/jest releases
+- `LINEAR_ACCESS_KEY_NODE_TEST_REPORTER` — pipeline-scoped access key for @currents/node-test-reporter releases
+- `SLACK_RELEASE_WEBHOOK_URL` — Slack incoming webhook for posting messages
+
+**Note:** Each pipeline access key is scoped to your specific release pipeline in Linear, ensuring operations only affect that pipeline.
+
 ## Publishing
 
 Dispatch the GitHub Actions Workflow to publish new releases: https://github.com/currents-dev/currents-reporter/actions/workflows/publish.yaml


### PR DESCRIPTION
Add linear-release.yaml workflow for tag-based release syncing. Update publish.yaml to mark releases complete in Linear and post to Slack. Each package uses its own Linear pipeline access key. Update README with Linear Releases documentation.

Made with [Cursor](https://cursor.com)