### PR TITLE
chore: update uuid to latest 11.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14646,9 +14646,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -15391,7 +15391,7 @@
         "tmp-promise": "^3.0.3",
         "ts-pattern": "^5.8.0",
         "unzipper": "^0.12.3",
-        "uuid": "11.1.0",
+        "uuid": "11.1.1",
         "xml2js": "^0.6.2",
         "xxhashjs": "^0.2.2"
       },
@@ -16506,7 +16506,7 @@
         "lodash": "^4.18.1",
         "source-map-support": "^0.5.21",
         "ts-pattern": "^5.8.0",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "yargs": "^17.7.2"
       },
       "devDependencies": {

--- a/packages/cmd/package.json
+++ b/packages/cmd/package.json
@@ -75,7 +75,7 @@
     "tmp-promise": "^3.0.3",
     "ts-pattern": "^5.8.0",
     "unzipper": "^0.12.3",
-    "uuid": "11.1.0",
+    "uuid": "11.1.1",
     "xml2js": "^0.6.2",
     "xxhashjs": "^0.2.2"
   },

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -47,7 +47,7 @@
     "lodash": "^4.18.1",
     "source-map-support": "^0.5.21",
     "ts-pattern": "^5.8.0",
-    "uuid": "^11.1.0",
+    "uuid": "^11.1.1",
     "yargs": "^17.7.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- bumped `uuid` in `packages/cmd/package.json` from `11.1.0` to `11.1.1`
- bumped `uuid` in `packages/jest/package.json` from `^11.1.0` to `^11.1.1`
- regenerated `package-lock.json` to resolve `uuid@11.1.1`

## Why
- pulls in the latest `11.x` security updates while staying on the CommonJS-compatible major line required by downstream users.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4abf4532-f90e-41d1-837f-e3934fc19568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4abf4532-f90e-41d1-837f-e3934fc19568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a shared dependency to a newer patch version in two package areas.
  * No user-facing behavior, scripts, or configuration changes were included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->